### PR TITLE
Fix package tool input field alias for part name

### DIFF
--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -39,7 +39,7 @@ class PackagePartOutput(_BaseModel):
 
 
 class PackageTextInput(PathInput):
-    partName: str = Field(alias="partName")
+    part_name: str = Field(alias="partName")
     encoding: Optional[str] = None
 
 
@@ -335,7 +335,7 @@ class LintOutput(_BaseModel):
 
 
 class PackageXmlInput(PathInput):
-    partName: str
+    part_name: str = Field(alias="partName")
 
 
 class PackageXmlOutput(_BaseModel):


### PR DESCRIPTION
## Summary
- rename the package text and XML input models to expose a snake_case `part_name` field while keeping the `partName` alias for validation

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd655e81a48329b0c389f3ef82c1b3