### PR TITLE
Fix add_table index detection for new tables

### DIFF
--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -510,7 +510,12 @@ class HwpxOps:
             border_fill_id_ref=border_fill,
         )
         tables = self._iter_tables(document)
-        index = tables.index(table)
+        element_id = id(table.element)
+        index = len(tables) - 1
+        for idx, candidate in enumerate(tables):
+            if id(candidate.element) == element_id:
+                index = idx
+                break
         self._save_document(document, resolved)
         return {"tableIndex": index, "cellCount": rows * cols}
 

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -91,3 +91,23 @@ def test_package_set_xml_tool_accepts_alias_arguments(ops_with_sample):
     )
 
     assert result == {"updated": False}
+
+
+def test_add_table_returns_valid_index(ops_with_sample):
+    ops, path = ops_with_sample
+    result = ops.add_table(str(path), rows=2, cols=2)
+
+    assert result["cellCount"] == 4
+    index = result["tableIndex"]
+
+    # ensure the table can be edited using the reported index
+    update = ops.set_table_cell_text(
+        str(path),
+        table_index=index,
+        row=0,
+        col=0,
+        text="이름",
+        dry_run=False,
+    )
+
+    assert update == {"ok": True}


### PR DESCRIPTION
## Summary
- ensure `add_table` locates the inserted table by comparing element identities instead of relying on direct object equality
- add a regression test that uses the reported table index to edit the new table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd7834e78c8329b2da64719310a543