### PR TITLE
Add tool to apply styles to specific text spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ MCP 클라이언트 설정에 추가할 때는 다음 예시를 활용하세요.
 - **find**, **find_runs_by_style**, **replace_text_in_runs** – 검색 및 스타일 보존 치환.
 - **add_paragraph**, **insert_paragraphs_bulk**, **add_table**, **set_table_cell_text**, **replace_table_region** – 문단·표 편집.
 - **add_shape**, **add_control**, **add_memo**, **attach_memo_field**, **add_memo_with_anchor**, **remove_memo** – 개체와 메모 관리.
-- **ensure_run_style**, **list_styles_and_bullets**, **apply_style_to_paragraphs** – 스타일 생성 및 적용.
+- **ensure_run_style**, **list_styles_and_bullets**, **apply_style_to_text_ranges**, **apply_style_to_paragraphs** – 스타일 생성 및 단어/문단 단위 적용.
 - **save**, **save_as**, **make_blank** – 저장 및 새 문서 생성.
 - **object_find_by_tag**, **object_find_by_attr** – XML 요소 검색.
 - **validate_structure**, **lint_text_conventions** – 문서 구조 검증 및 텍스트 린트.

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -264,6 +264,22 @@ class StylesAndBulletsOutput(_BaseModel):
     bullets: List[Dict[str, Any]]
 
 
+class TextSpanModel(_BaseModel):
+    paragraph_index: int = Field(alias="paragraphIndex")
+    start: int
+    end: int
+
+
+class ApplyStyleToTextInput(PathInput):
+    spans: Sequence[TextSpanModel]
+    char_pr_id_ref: str = Field(alias="charPrIDRef")
+    dry_run: bool = Field(True, alias="dryRun")
+
+
+class ApplyStyleToTextOutput(_BaseModel):
+    styledSpans: int
+
+
 class ApplyStyleInput(PathInput):
     paragraph_indexes: Sequence[int] = Field(alias="paragraphIndexes")
     char_pr_id_ref: str = Field(alias="charPrIDRef")
@@ -547,6 +563,13 @@ def build_tool_definitions() -> List[ToolDefinition]:
             input_model=PathInput,
             output_model=StylesAndBulletsOutput,
             func=_simple("list_styles_and_bullets"),
+        ),
+        ToolDefinition(
+            name="apply_style_to_text_ranges",
+            description="Apply a charPr style to specific text spans.",
+            input_model=ApplyStyleToTextInput,
+            output_model=ApplyStyleToTextOutput,
+            func=_simple("apply_style_to_text_ranges"),
         ),
         ToolDefinition(
             name="apply_style_to_paragraphs",


### PR DESCRIPTION
## Summary
- add support in HwpxOps for styling arbitrary text spans by splitting runs
- expose the functionality via a new apply_style_to_text_ranges MCP tool and document it
- cover the word-level styling flow with an end-to-end test

## Testing
- HWPX_MCP_ENABLE_OPC_WRITE=1 python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce824596908329b27f486cbc217a5e