### PR TITLE
Add logical table editing options and split tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ uvx hwpx-mcp-server
   - **문서 편집**
       - `replace_text_in_runs`: 스타일을 보존하며 텍스트 치환
       - `add_paragraph`, `insert_paragraphs_bulk`: 문단 추가
-      - `add_table`, `set_table_cell_text`, `replace_table_region`: 표 생성 및 편집
+      - `add_table`, `set_table_cell_text`, `replace_table_region`, `split_table_cell`: 표 생성·편집 및 병합 해제
       - `add_shape`, `add_control`: 개체 추가
       - `add_memo`, `attach_memo_field`, `add_memo_with_anchor`, `remove_memo`: 메모 관리
   - **스타일링**
@@ -99,6 +99,38 @@ uvx hwpx-mcp-server
       - `validate_structure`, `lint_text_conventions`: 문서 구조 검증 및 텍스트 린트
 
 \</details\>
+
+### 📐 표 편집 고급 옵션
+
+`set_table_cell_text`와 `replace_table_region`은 선택적인 `logical`/`splitMerged` 플래그를 지원합니다. `logical: true`로 지정하면 병합된 셀을 포함한 논리 좌표계를 그대로 사용할 수 있고, `splitMerged: true`를 함께 전달하면 쓰기 전에 자동으로 해당 병합 영역을 분할합니다. 병합을 직접 해제해야 할 때는 `split_table_cell` 도구가 원래 범위를 알려주면서 셀을 분할합니다.
+
+```jsonc
+{
+  "name": "set_table_cell_text",
+  "arguments": {
+    "path": "sample.hwpx",
+    "tableIndex": 0,
+    "row": 1,
+    "col": 1,
+    "text": "논리 좌표 편집",
+    "logical": true,
+    "splitMerged": true,
+    "dryRun": false
+  }
+}
+```
+
+위 예시는 2×2로 병합된 셀에 논리 좌표 `(1, 1)`을 지정하여 자동 분할 후 텍스트를 기록합니다. 분할 여부와 원래 범위를 확인하려면 `split_table_cell`을 호출하세요.
+
+```jsonc
+{
+  "name": "split_table_cell",
+  "arguments": {"path": "sample.hwpx", "tableIndex": 0, "row": 0, "col": 0},
+  "result": {"startRow": 0, "startCol": 0, "rowSpan": 2, "colSpan": 2}
+}
+```
+
+응답의 `rowSpan`/`colSpan` 값은 분할되기 전 병합 범위를 알려주므로, 프런트엔드 클라이언트가 UI 상태를 즉시 갱신할 수 있습니다.
 
 ## ☢️ 고급 기능: 직접 OPC 패키지 조작
 

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -172,6 +172,8 @@ class SetTableCellInput(PathInput):
     row: int
     col: int
     text: str
+    logical: Optional[bool] = Field(None, alias="logical")
+    split_merged: Optional[bool] = Field(None, alias="splitMerged")
     dry_run: bool = Field(True, alias="dryRun")
 
 
@@ -184,11 +186,26 @@ class ReplaceTableRegionInput(PathInput):
     start_row: int = Field(alias="startRow")
     start_col: int = Field(alias="startCol")
     values: Sequence[Sequence[str]]
+    logical: Optional[bool] = Field(None, alias="logical")
+    split_merged: Optional[bool] = Field(None, alias="splitMerged")
     dry_run: bool = Field(True, alias="dryRun")
 
 
 class ReplaceTableRegionOutput(_BaseModel):
     updatedCells: int
+
+
+class SplitTableCellInput(PathInput):
+    table_index: int = Field(alias="tableIndex")
+    row: int
+    col: int
+
+
+class SplitTableCellOutput(_BaseModel):
+    startRow: int
+    startCol: int
+    rowSpan: int
+    colSpan: int
 
 
 class AddShapeInput(PathInput):
@@ -507,6 +524,13 @@ def build_tool_definitions() -> List[ToolDefinition]:
             input_model=ReplaceTableRegionInput,
             output_model=ReplaceTableRegionOutput,
             func=_simple("replace_table_region"),
+        ),
+        ToolDefinition(
+            name="split_table_cell",
+            description="Split a merged table cell back into individual cells and report the original span.",
+            input_model=SplitTableCellInput,
+            output_model=SplitTableCellOutput,
+            func=_simple("split_table_cell"),
         ),
         ToolDefinition(
             name="add_shape",

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from hwpx.document import HwpxDocument
 from hwpx_mcp_server.hwpx_ops import HwpxOps
 from hwpx_mcp_server.tools import build_tool_definitions
 
@@ -111,3 +112,113 @@ def test_add_table_returns_valid_index(ops_with_sample):
     )
 
     assert update == {"ok": True}
+
+
+def test_set_table_cell_supports_logical_and_split_flags(ops_with_sample):
+    ops, path = ops_with_sample
+    table_info = ops.add_table(str(path), rows=3, cols=3)
+    index = table_info["tableIndex"]
+
+    document = HwpxDocument.open(path)
+    tables = []
+    for paragraph in document.paragraphs:
+        tables.extend(paragraph.tables)
+    tables[index].merge_cells(0, 0, 1, 1)
+    document.save(path)
+
+    logical_result = ops.set_table_cell_text(
+        str(path),
+        table_index=index,
+        row=1,
+        col=1,
+        text="Merged anchor",
+        logical=True,
+        dry_run=False,
+    )
+
+    assert logical_result == {"ok": True}
+
+    merged_state = HwpxDocument.open(path)
+    merged_tables: list = []
+    for paragraph in merged_state.paragraphs:
+        merged_tables.extend(paragraph.tables)
+    merged_cell = merged_tables[index].cell(0, 0)
+    assert merged_cell.span == (2, 2)
+    assert merged_cell.text == "Merged anchor"
+
+    split_result = ops.set_table_cell_text(
+        str(path),
+        table_index=index,
+        row=1,
+        col=1,
+        text="Bottom-right",
+        logical=True,
+        split_merged=True,
+        dry_run=False,
+    )
+
+    assert split_result == {"ok": True}
+
+    split_state = HwpxDocument.open(path)
+    split_tables: list = []
+    for paragraph in split_state.paragraphs:
+        split_tables.extend(paragraph.tables)
+    top_left = split_tables[index].cell(0, 0)
+    bottom_right = split_tables[index].cell(1, 1)
+    assert top_left.span == (1, 1)
+    assert top_left.text == "Merged anchor"
+    assert bottom_right.span == (1, 1)
+    assert bottom_right.text == "Bottom-right"
+
+
+def test_replace_region_and_split_tool_handle_merged_cells(ops_with_sample):
+    ops, path = ops_with_sample
+    table_info = ops.add_table(str(path), rows=3, cols=3)
+    index = table_info["tableIndex"]
+
+    document = HwpxDocument.open(path)
+    tables = []
+    for paragraph in document.paragraphs:
+        tables.extend(paragraph.tables)
+    target_table = tables[index]
+    target_table.merge_cells(0, 0, 1, 1)
+    document.save(path)
+
+    region_result = ops.replace_table_region(
+        str(path),
+        table_index=index,
+        start_row=0,
+        start_col=0,
+        values=[["A", "B"], ["C", "D"]],
+        logical=True,
+        split_merged=True,
+        dry_run=False,
+    )
+
+    assert region_result["updatedCells"] == 4
+
+    updated_state = HwpxDocument.open(path)
+    updated_tables: list = []
+    for paragraph in updated_state.paragraphs:
+        updated_tables.extend(paragraph.tables)
+    updated_table = updated_tables[index]
+    assert updated_table.cell(0, 0).span == (1, 1)
+    assert updated_table.cell(0, 0).text == "A"
+    assert updated_table.cell(0, 1).text == "B"
+    assert updated_table.cell(1, 0).text == "C"
+    assert updated_table.cell(1, 1).text == "D"
+
+    # Merge a new column region and split it using the dedicated tool
+    updated_table.merge_cells(0, 2, 1, 2)
+    updated_state.save(path)
+
+    split_meta = ops.split_table_cell(str(path), table_index=index, row=0, col=2)
+
+    assert split_meta == {"startRow": 0, "startCol": 2, "rowSpan": 2, "colSpan": 1}
+
+    split_state = HwpxDocument.open(path)
+    split_tables: list = []
+    for paragraph in split_state.paragraphs:
+        split_tables.extend(paragraph.tables)
+    column_cell = split_tables[index].cell(0, 2)
+    assert column_cell.span == (1, 1)


### PR DESCRIPTION
## Summary
- add logical and splitMerged flags to table editing tool schemas and expose a split_table_cell tool for merged cell management
- plumb the new options through HwpxOps, including helpful error guidance and a helper that returns span metadata after splitting merged cells
- extend unit and end-to-end tests plus README documentation to cover logical addressing, automatic splitting, and the dedicated split tool

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf5908fe908329858f754626b21c70