### PR TITLE
Default table editing tools persist by default

### DIFF
--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -592,7 +592,7 @@ class HwpxOps:
         col: int,
         text: str,
         *,
-        dry_run: bool = True,
+        dry_run: bool = False,
         logical: Optional[bool] = None,
         split_merged: Optional[bool] = None,
     ) -> Dict[str, Any]:
@@ -627,7 +627,7 @@ class HwpxOps:
         start_col: int,
         values: Sequence[Sequence[str]],
         *,
-        dry_run: bool = True,
+        dry_run: bool = False,
         logical: Optional[bool] = None,
         split_merged: Optional[bool] = None,
     ) -> Dict[str, Any]:

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -199,7 +199,7 @@ class SetTableCellInput(PathInput):
     text: str
     logical: Optional[bool] = Field(None, alias="logical")
     split_merged: Optional[bool] = Field(None, alias="splitMerged")
-    dry_run: bool = Field(True, alias="dryRun")
+    dry_run: bool = Field(False, alias="dryRun")
 
 
 class SetTableCellOutput(_BaseModel):
@@ -213,7 +213,7 @@ class ReplaceTableRegionInput(PathInput):
     values: Sequence[Sequence[str]]
     logical: Optional[bool] = Field(None, alias="logical")
     split_merged: Optional[bool] = Field(None, alias="splitMerged")
-    dry_run: bool = Field(True, alias="dryRun")
+    dry_run: bool = Field(False, alias="dryRun")
 
 
 class ReplaceTableRegionOutput(_BaseModel):

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -198,10 +198,15 @@ def test_add_table_returns_valid_index(ops_with_sample):
         row=0,
         col=0,
         text="이름",
-        dry_run=False,
     )
 
     assert update == {"ok": True}
+
+    refreshed = HwpxDocument.open(path)
+    refreshed_tables: list = []
+    for paragraph in refreshed.paragraphs:
+        refreshed_tables.extend(paragraph.tables)
+    assert refreshed_tables[index].cell(0, 0).text == "이름"
 
 
 def test_set_table_cell_supports_logical_and_split_flags(ops_with_sample):
@@ -223,7 +228,6 @@ def test_set_table_cell_supports_logical_and_split_flags(ops_with_sample):
         col=1,
         text="Merged anchor",
         logical=True,
-        dry_run=False,
     )
 
     assert logical_result == {"ok": True}
@@ -244,7 +248,6 @@ def test_set_table_cell_supports_logical_and_split_flags(ops_with_sample):
         text="Bottom-right",
         logical=True,
         split_merged=True,
-        dry_run=False,
     )
 
     assert split_result == {"ok": True}
@@ -282,7 +285,6 @@ def test_replace_region_and_split_tool_handle_merged_cells(ops_with_sample):
         values=[["A", "B"], ["C", "D"]],
         logical=True,
         split_merged=True,
-        dry_run=False,
     )
 
     assert region_result["updatedCells"] == 4

--- a/tests/test_mcp_end_to_end.py
+++ b/tests/test_mcp_end_to_end.py
@@ -357,9 +357,16 @@ def test_table_workflow(
         col=1,
         text="헤더",
         logical=True,
-        dryRun=False,
     )
     assert set_result == {"ok": True}
+
+    merged_state = HwpxDocument.open(doc_path)
+    merged_tables: list = []
+    for paragraph in merged_state.paragraphs:
+        merged_tables.extend(paragraph.tables)
+    merged_anchor = merged_tables[table_index].cell(0, 0)
+    assert merged_anchor.span == (2, 2)
+    assert merged_anchor.text == "헤더"
 
     replace_result = _call(
         tool_map,
@@ -372,7 +379,6 @@ def test_table_workflow(
         values=[["A", "B"], ["C", "D"]],
         logical=True,
         splitMerged=True,
-        dryRun=False,
     )
     assert replace_result["updatedCells"] == 4
 
@@ -734,7 +740,6 @@ def test_failure_paths_raise_runtime_errors(
             startRow=0,
             startCol=0,
             values=[["X"]],
-            dryRun=False,
         )
 
 


### PR DESCRIPTION
## Summary
- default the table cell editing tool inputs to `dryRun=False` so the schema reflects live updates
- align the underlying HwpxOps table writers with the same default behaviour
- refresh table workflow tests to rely on the implicit persistence and assert saved cell text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf97a35d708329aa5cec3b9a380e75