### PR TITLE
Remove OPC write tools and document read-only package helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@
       "env": {
         "HWPX_MCP_PAGING_PARA_LIMIT": "200",
         "HWPX_MCP_AUTOBACKUP": "1",
-        "HWPX_MCP_ENABLE_OPC_WRITE": "1",
         "LOG_LEVEL": "INFO"
       }
     }
@@ -65,7 +64,6 @@ uvx hwpx-mcp-server
 | --- | --- | --- |
 | `HWPX_MCP_PAGING_PARA_LIMIT` | 페이지네이션 도구가 반환할 최대 문단 수 | `200` |
 | `HWPX_MCP_AUTOBACKUP` | `1`이면 저장 전 `<file>.bak` 백업 생성 | `0` |
-| `HWPX_MCP_ENABLE_OPC_WRITE` | `package_set_text` / `package_set_xml` 사용 허용 | `0` |
 | `LOG_LEVEL` | stderr에 JSONL 형식으로 출력할 로그 레벨 | `INFO` |
 
 > ℹ️ `read_text` 도구는 기본적으로 최대 200개의 문단을 반환합니다. 더 큰 덤프가 필요하면 도구 호출 시 `limit` 인수를 직접 지정하거나 `HWPX_MCP_PAGING_PARA_LIMIT` 환경 변수를 확장하세요. 이는 Microsoft Office Word에서 필요한 범위만 순차적으로 읽는 워크플로와 동일합니다.
@@ -177,19 +175,15 @@ uvx hwpx-mcp-server
 
 응답의 `rowSpan`/`colSpan` 값은 분할되기 전 병합 범위를 알려주므로, 프런트엔드 클라이언트가 UI 상태를 즉시 갱신할 수 있습니다.
 
-## ☢️ 고급 기능: 직접 OPC 패키지 조작
+## ☢️ 고급 기능: OPC 패키지 내부 살펴보기
 
-> **⚠️ 경고:** 아래 도구들은 HWPX 문서의 내부 OPC 파트를 직접 조작합니다. 잘못 사용하면 문서를 손상시킬 수 있으므로, 내부 구조를 충분히 이해한 상태에서 사용해야 합니다. 쓰기 작업은 기본적으로 비활성화되어 있습니다.
-
-활성화를 위해서는 `HWPX_MCP_ENABLE_OPC_WRITE` 환경 변수를 `1`로 설정해야 합니다. 또한, `package_set_text`, `package_set_xml` 도구는 기본적으로 `dryRun: true` 모드로 동작하여 실제 파일에 쓰지 않습니다. 변경 사항을 즉시 적용하려면 `dryRun: false`로 설정해야 합니다.
+> **⚠️ 경고:** 아래 도구들은 HWPX 문서의 내부 OPC 파트를 그대로 노출합니다. 구조를 잘못 해석하면 문서를 오해할 수 있으니, 스키마와 관계를 충분히 이해한 상태에서 활용하세요. 현재 MCP 서버는 의도치 않은 손상을 막기 위해 **읽기 전용 도구만** 제공합니다.
 
   * `package_parts`: 패키지에 포함된 모든 OPC 파트의 경로 목록을 확인합니다.
   * `package_get_text`: 지정한 파트를 텍스트로 읽어옵니다 (인코딩 지정 가능).
-  * `package_set_text`: 텍스트 파트의 내용을 교체합니다 (`dryRun` 해제 및 쓰기 권한 필요).
   * `package_get_xml`: 지정한 파트를 XML 문자열로 반환합니다.
-  * `package_set_xml`: XML 파트의 내용을 교체합니다 (`dryRun` 해제 및 쓰기 권한 필요).
 
-#### 시나리오 예시 (읽기 전용)
+#### 시나리오 예시
 
 스타일 정의 XML 파일(`Styles.xml`)의 내용을 확인하고 싶다면:
 
@@ -204,11 +198,11 @@ uvx hwpx-mcp-server
 # 1. 테스트 의존성 설치
 python -m pip install -e .[test]
 
-# 2. 테스트 실행 (OPC 쓰기 활성화)
-HWPX_MCP_ENABLE_OPC_WRITE=1 python -m pytest
+# 2. 테스트 실행
+python -m pytest
 ```
 
-`tests/test_mcp_end_to_end.py`는 서버가 노출하는 모든 도구를 실제로 호출하여 텍스트, 표, 메모 편집, OPC 패키지 쓰기, 자동 백업 생성 등 핵심 동작을 완벽하게 검증합니다.
+`tests/test_mcp_end_to_end.py`는 서버가 노출하는 대부분의 도구를 실제로 호출하여 텍스트, 표, 메모 편집, OPC 패키지 읽기, 자동 백업 생성 등 핵심 동작을 완벽하게 검증합니다.
 
 ## 🧑‍💻 개발 참고
 

--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -47,12 +47,10 @@ class HwpxOps:
         base_directory: Path | None = None,
         paging_paragraph_limit: int = DEFAULT_PAGING_PARAGRAPH_LIMIT,
         auto_backup: bool = False,
-        enable_opc_write: bool = False,
     ) -> None:
         self.base_directory = (base_directory or Path.cwd()).expanduser().resolve()
         self.paging_limit = max(1, paging_paragraph_limit)
         self.auto_backup = auto_backup
-        self.enable_opc_write = enable_opc_write
 
     # ------------------------------------------------------------------
     # Basic helpers
@@ -257,25 +255,6 @@ class HwpxOps:
         text = package.get_text(part_name, encoding=encoding or "utf-8")
         return {"text": text}
 
-    def package_set_text(
-        self,
-        path: str,
-        part_name: str,
-        text: str,
-        *,
-        encoding: str | None = None,
-        dry_run: bool = True,
-    ) -> Dict[str, Any]:
-        if not self.enable_opc_write:
-            raise PermissionError("OPC write access is disabled by default")
-        resolved = self._resolve_path(path)
-        package = HwpxPackage.open(resolved)
-        package.set_part(part_name, text.encode(encoding or "utf-8"))
-        if dry_run:
-            return {"updated": False}
-        self._maybe_backup(resolved)
-        package.save(resolved)
-        return {"updated": True}
 
     # ------------------------------------------------------------------
     # Text extraction
@@ -1200,24 +1179,3 @@ class HwpxOps:
         xml_string = ET.tostring(element, encoding="unicode")
         return {"xmlString": xml_string}
 
-    def package_set_xml(
-        self,
-        path: str,
-        part_name: str,
-        xml_string: str,
-        *,
-        dry_run: bool = True,
-    ) -> Dict[str, Any]:
-        if not self.enable_opc_write:
-            raise PermissionError("OPC write access is disabled by default")
-        resolved = self._resolve_path(path)
-        from xml.etree import ElementTree as ET
-
-        element = ET.fromstring(xml_string)
-        package = HwpxPackage.open(resolved)
-        package.set_xml(part_name, element)
-        if dry_run:
-            return {"updated": False}
-        self._maybe_backup(resolved)
-        package.save(resolved)
-        return {"updated": True}

--- a/src/hwpx_mcp_server/server.py
+++ b/src/hwpx_mcp_server/server.py
@@ -89,7 +89,6 @@ def main() -> int:
         base_directory=base_directory,
         paging_paragraph_limit=paging_value,
         auto_backup=_bool_env("HWPX_MCP_AUTOBACKUP"),
-        enable_opc_write=_bool_env("HWPX_MCP_ENABLE_OPC_WRITE"),
     )
 
     tools = build_tool_definitions()

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -47,15 +47,6 @@ class PackageTextOutput(_BaseModel):
     text: str
 
 
-class PackageSetTextInput(PackageTextInput):
-    text: str
-    dry_run: bool = Field(True, alias="dryRun")
-
-
-class UpdatedOutput(_BaseModel):
-    updated: bool
-
-
 class ReadTextInput(PathInput):
     offset: int = 0
     limit: Optional[int] = None
@@ -400,11 +391,6 @@ class PackageXmlOutput(_BaseModel):
     xmlString: str
 
 
-class PackageSetXmlInput(PackageXmlInput):
-    xml_string: str = Field(alias="xmlString")
-    dry_run: bool = Field(True, alias="dryRun")
-
-
 @dataclass
 class ToolDefinition:
     name: str
@@ -472,13 +458,6 @@ def build_tool_definitions() -> List[ToolDefinition]:
             input_model=PackageTextInput,
             output_model=PackageTextOutput,
             func=_simple("package_get_text"),
-        ),
-        ToolDefinition(
-            name="package_set_text",
-            description="Write text into an OPC part (requires OPC write flag).",
-            input_model=PackageSetTextInput,
-            output_model=UpdatedOutput,
-            func=_simple("package_set_text"),
         ),
         ToolDefinition(
             name="read_text",
@@ -699,12 +678,5 @@ def build_tool_definitions() -> List[ToolDefinition]:
             input_model=PackageXmlInput,
             output_model=PackageXmlOutput,
             func=_simple("package_get_xml"),
-        ),
-        ToolDefinition(
-            name="package_set_xml",
-            description="Write XML into an OPC part (requires OPC write flag).",
-            input_model=PackageSetXmlInput,
-            output_model=UpdatedOutput,
-            func=_simple("package_set_xml"),
         ),
     ]

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -152,38 +152,6 @@ def test_save_as_creates_new_file(ops_with_sample, tmp_path):
     result = ops.save_as(str(path), str(out))
     assert Path(result["outPath"]).exists()
 
-
-def test_package_set_xml_tool_accepts_alias_arguments(ops_with_sample):
-    ops, path = ops_with_sample
-    ops.enable_opc_write = True
-    tools = {tool.name: tool for tool in build_tool_definitions()}
-    package_set_tool = tools["package_set_xml"]
-    schema = package_set_tool.input_model.model_json_schema(by_alias=True)
-    assert "xmlString" in schema["properties"]
-
-    part_name = "Contents/section0.xml"
-    package_get_tool = tools["package_get_xml"]
-    xml_payload = package_get_tool.call(
-        ops,
-        {
-            "path": str(path),
-            "partName": part_name,
-        },
-    )
-
-    result = package_set_tool.call(
-        ops,
-        {
-            "path": str(path),
-            "partName": part_name,
-            "xmlString": xml_payload["xmlString"],
-            "dryRun": True,
-        },
-    )
-
-    assert result == {"updated": False}
-
-
 def test_add_table_returns_valid_index(ops_with_sample):
     ops, path = ops_with_sample
     result = ops.add_table(str(path), rows=2, cols=2)


### PR DESCRIPTION
## Summary
- drop the optional OPC write flag and helper methods from `HwpxOps`
- remove `package_set_*` tool definitions and update docs to describe read-only package helpers
- simplify tests to cover read-only scenarios

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d003a46e808329aa213284af52be76