### PR TITLE
Ensure tool schemas use JSON Schema draft-07

### DIFF
--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -7,12 +7,95 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import mcp.types as types
 from pydantic import BaseModel, Field, ConfigDict
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 
 from .hwpx_ops import HwpxOps
 
 
 class _BaseModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class _Draft7JsonSchemaGenerator(GenerateJsonSchema):
+    schema_dialect = "http://json-schema.org/draft-07/schema#"
+    ref_template = "#/definitions/{model}"
+
+
+def _is_null_schema(schema: JsonSchemaValue) -> bool:
+    if not isinstance(schema, dict):
+        return False
+    if schema.get("type") != "null":
+        return False
+    allowed_keys = {"type", "title", "description", "default", "examples"}
+    return set(schema).issubset(allowed_keys)
+
+
+def _collapse_nullable(schema: Dict[str, Any]) -> Dict[str, Any]:
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        null_entries = [item for item in any_of if _is_null_schema(item)]
+        non_null_entries = [item for item in any_of if not _is_null_schema(item)]
+        if len(non_null_entries) == 1 and null_entries:
+            base: Dict[str, Any] = {k: v for k, v in schema.items() if k != "anyOf"}
+            non_null = non_null_entries[0]
+            if isinstance(non_null, dict):
+                for key, value in non_null.items():
+                    if key in {"title", "description"} and key in base:
+                        continue
+                    base[key] = value
+            base["nullable"] = True
+            return base
+
+    type_value = schema.get("type")
+    if isinstance(type_value, list):
+        non_null_types = [t for t in type_value if t != "null"]
+        if len(non_null_types) == 1 and len(non_null_types) != len(type_value):
+            schema["type"] = non_null_types[0]
+            schema["nullable"] = True
+
+    return schema
+
+
+def _normalize_draft7_schema(value: JsonSchemaValue) -> JsonSchemaValue:
+    if isinstance(value, dict):
+        normalized: Dict[str, Any] = {}
+        for key, item in value.items():
+            if key == "$schema":
+                continue
+            if key == "$defs" and isinstance(item, dict):
+                normalized["definitions"] = {
+                    name: _normalize_draft7_schema(sub_schema)
+                    for name, sub_schema in item.items()
+                }
+                continue
+            if key == "$ref" and isinstance(item, str) and item.startswith("#/$defs/"):
+                normalized["$ref"] = "#/definitions/" + item[len("#/$defs/"):]
+                continue
+            normalized[key] = _normalize_draft7_schema(item)
+
+        if "anyOf" in normalized:
+            normalized = _collapse_nullable(normalized)
+
+        return normalized
+
+    if isinstance(value, list):
+        return [_normalize_draft7_schema(item) for item in value]
+
+    return value
+
+
+def _model_json_schema(model: type[_BaseModel], *, by_alias: bool) -> Dict[str, Any]:
+    raw = model.model_json_schema(
+        by_alias=by_alias,
+        schema_generator=_Draft7JsonSchemaGenerator,
+    )
+    schema = _normalize_draft7_schema(raw)
+    if not isinstance(schema, dict):
+        raise TypeError("Expected model_json_schema to return a mapping")
+    if schema.get("type") != "object":
+        schema["type"] = "object"
+    schema.setdefault("properties", {})
+    return schema
 
 
 class PathInput(_BaseModel):
@@ -418,8 +501,8 @@ class ToolDefinition:
         return types.Tool(
             name=self.name,
             description=self.description,
-            inputSchema=self.input_model.model_json_schema(by_alias=True),
-            outputSchema=self.output_model.model_json_schema(by_alias=True),
+            inputSchema=_model_json_schema(self.input_model, by_alias=True),
+            outputSchema=_model_json_schema(self.output_model, by_alias=True),
         )
 
     def call(self, ops: HwpxOps, arguments: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add a draft-07 JSON schema generator that normalizes references and nullable fields
- use the helper when publishing tool schemas so generated MCP metadata stays draft-07 compatible
- add regression coverage that checks six representative tools expose draft-07 compliant schemas with required fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0e83e7e508329ab05072e073e03ea