### PR TITLE
Fix table border style handling for table insertion

### DIFF
--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -183,6 +183,17 @@ class HwpxOps:
             raise HwpxOperationError("char property does not expose an identifier")
         return char_id
 
+    def _resolve_table_border_fill(self, border_style: Optional[str]) -> Optional[str]:
+        if border_style is None:
+            return None
+
+        normalized = border_style.strip().lower()
+        if not normalized or normalized == "solid":
+            return None
+        if normalized == "none":
+            return "0"
+        raise ValueError(f"Unsupported border style: {border_style}")
+
     def _create_underline_element(self, color: str) -> Any:
         from xml.etree import ElementTree as ET
 
@@ -571,9 +582,7 @@ class HwpxOps:
         border_style: str | None = None,
     ) -> Dict[str, Any]:
         document, resolved = self._open_document(path)
-        border_fill = "0"
-        if border_style == "none":
-            border_fill = "0"
+        border_fill = self._resolve_table_border_fill(border_style)
         table = document.add_table(
             rows,
             cols,

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence, Literal
 
 import mcp.types as types
 from pydantic import BaseModel, Field, ConfigDict
@@ -393,7 +393,7 @@ class AddTableInput(PathInput):
     rows: int
     cols: int
     section_index: Optional[int] = Field(None, alias="sectionIndex")
-    border_style: Optional[str] = Field(None, alias="borderStyle")
+    border_style: Optional[Literal["solid", "none"]] = Field(None, alias="borderStyle")
 
 
 class AddTableOutput(_BaseModel):

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -238,7 +238,25 @@ def test_add_table_returns_valid_index(ops_with_sample):
     refreshed_tables: list = []
     for paragraph in refreshed.paragraphs:
         refreshed_tables.extend(paragraph.tables)
-    assert refreshed_tables[index].cell(0, 0).text == "이름"
+    target_table = refreshed_tables[index]
+    assert target_table.cell(0, 0).text == "이름"
+
+    basic_border_id = str(refreshed._root.ensure_basic_border_fill())
+    assert target_table.element.get("borderFillIDRef") == basic_border_id
+
+
+def test_add_table_border_style_none_uses_empty_border(ops_with_sample):
+    ops, path = ops_with_sample
+    result = ops.add_table(str(path), rows=2, cols=2, border_style="none")
+
+    index = result["tableIndex"]
+
+    refreshed = HwpxDocument.open(path)
+    refreshed_tables: list = []
+    for paragraph in refreshed.paragraphs:
+        refreshed_tables.extend(paragraph.tables)
+
+    assert refreshed_tables[index].element.get("borderFillIDRef") == "0"
 
 
 def test_set_table_cell_supports_logical_and_split_flags(ops_with_sample):


### PR DESCRIPTION
## Summary
- compute table border fill IDs through a helper so default insertions reuse the document basic border fill
- restrict the add_table tool input to explicit border style options
- extend the hwpx_ops tests to cover default and none border style behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1dbe337308329919720eeadb1f422