### PR TITLE
feat: draft-07-safe schema builder + plan/preview/apply (behind flag)

### DIFF
--- a/src/hwpx_mcp_server/core/context.py
+++ b/src/hwpx_mcp_server/core/context.py
@@ -1,0 +1,87 @@
+"""Search and context utilities for hardened tools."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    node_id: str
+    paragraph_index: int
+    start: int
+    end: int
+    match: str
+    context: str
+
+
+def _iter_substring_matches(text: str, pattern: str) -> Iterable[tuple[int, int, str]]:
+    start = 0
+    length = len(pattern)
+    if length == 0:
+        return
+    while True:
+        index = text.find(pattern, start)
+        if index == -1:
+            break
+        yield index, index + length, pattern
+        start = index + length
+
+
+def search_paragraphs(
+    paragraphs: Sequence[str],
+    *,
+    pattern: str,
+    limit: int,
+    use_regex: bool,
+    node_resolver: Callable[[int], str],
+    context_radius: int = 20,
+) -> List[SearchHit]:
+    hits: List[SearchHit] = []
+    if not pattern:
+        return hits
+
+    matcher = None
+    if use_regex:
+        matcher = re.compile(pattern)
+
+    for index, paragraph in enumerate(paragraphs):
+        matches: Iterable[tuple[int, int, str]]
+        if matcher is not None:
+            matches = ((m.start(), m.end(), m.group(0)) for m in matcher.finditer(paragraph))
+        else:
+            matches = _iter_substring_matches(paragraph, pattern)
+        for start, end, match_text in matches:
+            context = paragraph[max(0, start - context_radius) : min(len(paragraph), end + context_radius)]
+            hits.append(
+                SearchHit(
+                    node_id=node_resolver(index),
+                    paragraph_index=index,
+                    start=start,
+                    end=end,
+                    match=match_text,
+                    context=context,
+                )
+            )
+            if len(hits) >= limit:
+                return hits
+    return hits
+
+
+def window_for_paragraph(
+    paragraphs: Sequence[str],
+    index: int,
+    *,
+    radius: int,
+) -> dict:
+    radius = max(1, min(radius, 3))
+    focus = paragraphs[index] if 0 <= index < len(paragraphs) else ""
+    before = list(paragraphs[max(0, index - radius) : index])
+    after = list(paragraphs[index + 1 : index + 1 + radius])
+    return {
+        "before": before,
+        "focus": focus,
+        "after": after,
+    }

--- a/src/hwpx_mcp_server/core/diff.py
+++ b/src/hwpx_mcp_server/core/diff.py
@@ -1,0 +1,52 @@
+"""Lightweight helpers for representing logical diffs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+
+@dataclass(frozen=True)
+class ParagraphMatch:
+    """Capture a single pattern match inside a paragraph."""
+
+    paragraph_index: int
+    start: int
+    end: int
+    text: str
+
+    def context(self, paragraph: str, radius: int = 20) -> str:
+        left = max(self.start - radius, 0)
+        right = min(self.end + radius, len(paragraph))
+        snippet = paragraph[left:right]
+        return snippet
+
+
+@dataclass(frozen=True)
+class ParagraphDiff:
+    """A replace operation scoped to a paragraph."""
+
+    paragraph_index: int
+    start: int
+    end: int
+    before: str
+    after: str
+
+    def apply(self, paragraphs: Sequence[str]) -> List[str]:
+        updated = list(paragraphs)
+        if self.paragraph_index >= len(updated):
+            raise ValueError("paragraph index out of range")
+        original = updated[self.paragraph_index]
+        if original[self.start : self.end] != self.before:
+            raise ValueError("paragraph content changed before apply")
+        updated[self.paragraph_index] = (
+            original[: self.start] + self.after + original[self.end :]
+        )
+        return updated
+
+    def as_preview(self) -> Dict[str, object]:
+        return {
+            "paragraphIndex": self.paragraph_index,
+            "before": self.before,
+            "after": self.after,
+        }

--- a/src/hwpx_mcp_server/core/handles.py
+++ b/src/hwpx_mcp_server/core/handles.py
@@ -1,0 +1,23 @@
+"""Helpers for generating stable handles for logical nodes."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable, Tuple
+
+
+def _normalize_parts(parts: Iterable[str | int]) -> Tuple[str, ...]:
+    normalized: list[str] = []
+    for part in parts:
+        text = str(part)
+        normalized.append(text)
+    return tuple(normalized)
+
+
+def stable_node_id(parts: Iterable[str | int]) -> str:
+    """Return a deterministic identifier for the provided structural path."""
+
+    normalized = _normalize_parts(parts)
+    joined = "::".join(normalized)
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+    return f"n_{digest}"

--- a/src/hwpx_mcp_server/core/plan.py
+++ b/src/hwpx_mcp_server/core/plan.py
@@ -1,0 +1,638 @@
+"""Planning pipeline and validation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, conint, constr, model_validator
+
+from ..metadata import tools_meta
+from .context import SearchHit, search_paragraphs, window_for_paragraph
+from .diff import ParagraphDiff, ParagraphMatch
+from .handles import stable_node_id
+from .txn import IdempotentReplayError, TransactionManager
+
+
+class PlanModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class Target(PlanModel):
+    node_id: Optional[constr(pattern=r"^n_[A-Za-z0-9]{8,}$")] = Field(None, alias="nodeId")
+    section_index: Optional[conint(ge=0)] = Field(None, alias="sectionIndex")
+    para_index: Optional[conint(ge=0)] = Field(None, alias="paraIndex")
+
+    @model_validator(mode="after")
+    def check_selector(self) -> "Target":
+        has_node = self.node_id is not None
+        has_indices = self.section_index is not None and self.para_index is not None
+        if has_node == has_indices:
+            raise ValueError("target must specify nodeId or sectionIndex+paraIndex")
+        return self
+
+
+class ReplaceTextArgs(PlanModel):
+    target: Target
+    match: constr(min_length=1)
+    replacement: str = ""
+    limit: conint(ge=1, le=100) = 1
+    dry_run: bool = Field(True, alias="dryRun")
+    atomic: bool = True
+
+
+class PlanEditInput(PlanModel):
+    path: constr(min_length=1)
+    operations: List[ReplaceTextArgs]
+    trace_id: Optional[constr(min_length=1)] = Field(None, alias="traceId")
+
+    @model_validator(mode="after")
+    def ensure_operations(self) -> "PlanEditInput":
+        if not self.operations:
+            raise ValueError("operations must not be empty")
+        return self
+
+
+class PreviewEditInput(PlanModel):
+    plan_id: constr(min_length=1) = Field(alias="planId")
+    trace_id: Optional[constr(min_length=1)] = Field(None, alias="traceId")
+
+
+class ApplyEditInput(PlanModel):
+    plan_id: constr(min_length=1) = Field(alias="planId")
+    confirm: bool
+    idempotency_key: Optional[constr(min_length=1)] = Field(None, alias="idempotencyKey")
+    trace_id: Optional[constr(min_length=1)] = Field(None, alias="traceId")
+
+
+class NextAction(PlanModel):
+    tool: constr(min_length=1)
+    example_json: constr(min_length=2) = Field(alias="exampleJson")
+
+
+class DiffPreview(PlanModel):
+    paragraph_index: conint(ge=0) = Field(alias="paragraphIndex")
+    before: str
+    after: str
+
+
+class Candidate(PlanModel):
+    node_id: constr(min_length=1) = Field(alias="nodeId")
+    paragraph_index: conint(ge=0) = Field(alias="paragraphIndex")
+    context: constr(min_length=1)
+
+
+class PlanSummaryData(PlanModel):
+    plan_id: constr(min_length=1) = Field(alias="planId")
+    complexity_score: conint(ge=0) = Field(alias="complexityScore")
+    safe: bool
+    preview_available: bool = Field(alias="previewAvailable")
+
+
+class PreviewData(PlanModel):
+    plan_id: constr(min_length=1) = Field(alias="planId")
+    diff: List[DiffPreview]
+    complexity_score: conint(ge=0) = Field(alias="complexityScore")
+    safe: bool
+
+
+class ApplyData(PlanModel):
+    plan_id: constr(min_length=1) = Field(alias="planId")
+    applied: bool
+
+
+class ResponseData(PlanModel):
+    plan: Optional[PlanSummaryData] = None
+    preview: Optional[PreviewData] = None
+    apply: Optional[ApplyData] = None
+
+
+ErrorCode = Literal[
+    "AMBIGUOUS_TARGET",
+    "UNSAFE_WILDCARD",
+    "MISSING_NODE",
+    "RANGE_OUT_OF_BOUNDS",
+    "EMPTY_MATCH",
+    "CONFLICTING_TARGETS",
+    "PREVIEW_REQUIRED",
+    "IDEMPOTENT_REPLAY",
+]
+
+
+class ErrorPayload(PlanModel):
+    error_code: ErrorCode = Field(alias="errorCode")
+    message: str
+    candidates: List[Candidate] = Field(default_factory=list)
+    hint: Optional[str] = None
+
+
+class ServerResponse(PlanModel):
+    ok: bool
+    data: Optional[ResponseData] = None
+    error: Optional[ErrorPayload] = None
+    next_actions: List[NextAction] = Field(default_factory=list, alias="nextActions")
+    api_version: constr(min_length=1) = Field("1.2.0", alias="apiVersion")
+    doc_version: constr(min_length=1) = Field(alias="docVersion")
+    trace_id: constr(min_length=1) = Field(alias="traceId")
+
+
+class SearchInput(PlanModel):
+    path: constr(min_length=1)
+    pattern: constr(min_length=1)
+    scope: Optional[constr(min_length=1)] = None
+    is_regex: bool = Field(False, alias="isRegex")
+    limit: conint(ge=1, le=50) = 20
+
+
+class SearchHitModel(PlanModel):
+    node_id: constr(min_length=1) = Field(alias="nodeId")
+    paragraph_index: conint(ge=0) = Field(alias="paragraphIndex")
+    match: str
+    context: str
+
+
+class SearchOutput(PlanModel):
+    matches: List[SearchHitModel]
+
+
+class GetContextInput(PlanModel):
+    path: constr(min_length=1)
+    target: Target
+    window: conint(ge=1, le=3) = 1
+
+
+class ContextOutput(PlanModel):
+    before: List[str]
+    focus: str
+    after: List[str]
+
+
+class PipelineError(RuntimeError):
+    """Exception used to carry pipeline validation failures."""
+
+    def __init__(
+        self,
+        error_code: str,
+        message: str,
+        *,
+        candidates: Optional[List[Candidate]] = None,
+        hint: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.message = message
+        self.candidates = candidates or []
+        self.hint = hint
+
+
+@dataclass
+class CandidateInfo:
+    node_id: str
+    paragraph_index: int
+    context: str
+
+    def to_model(self) -> Candidate:
+        return Candidate(nodeId=self.node_id, paragraphIndex=self.paragraph_index, context=self.context)
+
+
+@dataclass
+class DocumentState:
+    doc_id: str
+    content: str
+    version: int = 1
+    _paragraphs: List[str] = field(init=False, repr=False)
+    _node_lookup: Dict[str, int] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._rebuild()
+
+    def _rebuild(self) -> None:
+        self._paragraphs = self.content.splitlines()
+        self._node_lookup = {
+            stable_node_id((self.doc_id, index)): index for index in range(len(self._paragraphs))
+        }
+
+    def paragraphs(self) -> List[str]:
+        return list(self._paragraphs)
+
+    def node_for_index(self, index: int) -> str:
+        return stable_node_id((self.doc_id, index))
+
+    def index_for_node(self, node_id: str) -> Optional[int]:
+        return self._node_lookup.get(node_id)
+
+    def set_content(self, content: str, *, bump_version: bool = True) -> None:
+        self.content = content
+        if bump_version:
+            self.version += 1
+        self._rebuild()
+
+
+@dataclass
+class PlanRecord:
+    plan_id: str
+    doc_id: str
+    trace_id: str
+    base_version: int
+    diffs: List[ParagraphDiff]
+    candidates: List[CandidateInfo]
+    unsafe: bool
+    complexity_score: int
+    consumed: bool = False
+
+    @property
+    def safe(self) -> bool:
+        return not self.candidates and not self.unsafe
+
+
+@dataclass
+class PreviewRecord:
+    plan_id: str
+    doc_id: str
+    diff_preview: List[DiffPreview]
+    complexity_score: int
+    safe: bool
+    trace_id: str
+
+
+class PlanManager:
+    """Manage plan/preview/apply lifecycle."""
+
+    def __init__(self) -> None:
+        self._documents: Dict[str, DocumentState] = {}
+        self._plans: Dict[str, PlanRecord] = {}
+        self._previews: Dict[str, PreviewRecord] = {}
+        self._txn = TransactionManager[List[str]]()
+
+    # ------------------------------------------------------------------
+    # Document lifecycle helpers
+    # ------------------------------------------------------------------
+    def register_document(self, doc_id: str, content: str) -> None:
+        state = self._documents.get(doc_id)
+        if state is None:
+            self._documents[doc_id] = DocumentState(doc_id=doc_id, content=content)
+        else:
+            state.set_content(content)
+
+    def has_document(self, doc_id: str) -> bool:
+        return doc_id in self._documents
+
+    def get_document_text(self, doc_id: str) -> str:
+        state = self._documents.get(doc_id)
+        if state is None:
+            raise PipelineError("MISSING_NODE", f"document '{doc_id}' is not registered")
+        return state.content
+
+    def replace_document(self, doc_id: str, content: str) -> None:
+        state = self._documents.get(doc_id)
+        if state is None:
+            self._documents[doc_id] = DocumentState(doc_id=doc_id, content=content)
+        else:
+            state.set_content(content)
+
+    def doc_version(self, doc_id: str) -> str:
+        state = self._documents.get(doc_id)
+        if state is None:
+            return "0"
+        return str(state.version)
+
+    # ------------------------------------------------------------------
+    # Planning lifecycle
+    # ------------------------------------------------------------------
+    def create_plan_record(
+        self,
+        doc_id: str,
+        operations: Sequence[ReplaceTextArgs | Dict[str, object]],
+        *,
+        trace_id: Optional[str] = None,
+    ) -> PlanRecord:
+        state = self._documents.get(doc_id)
+        if state is None:
+            raise PipelineError("MISSING_NODE", f"document '{doc_id}' is not registered")
+
+        resolved_ops: List[ReplaceTextArgs] = []
+        for op in operations:
+            if isinstance(op, ReplaceTextArgs):
+                resolved_ops.append(op)
+            else:
+                try:
+                    resolved_ops.append(ReplaceTextArgs.model_validate(op))
+                except ValidationError as exc:  # pragma: no cover - defensive
+                    raise PipelineError("EMPTY_MATCH", str(exc)) from exc
+
+        plan_id = f"pln_{uuid4().hex}"
+        paragraphs = state.paragraphs()
+
+        all_diffs: List[ParagraphDiff] = []
+        candidates: List[CandidateInfo] = []
+        unsafe = False
+
+        for op in resolved_ops:
+            matches = self._find_matches(state, paragraphs, op)
+            if not matches:
+                raise PipelineError("MISSING_NODE", "target match not found")
+
+            if op.limit < len(matches):
+                unsafe = True
+
+            if len(matches) > 1:
+                for match in matches[:5]:
+                    context = match.context(paragraphs[match.paragraph_index])
+                    candidates.append(
+                        CandidateInfo(
+                            node_id=state.node_for_index(match.paragraph_index),
+                            paragraph_index=match.paragraph_index,
+                            context=context,
+                        )
+                    )
+
+            for match in matches[: op.limit]:
+                all_diffs.append(
+                    ParagraphDiff(
+                        paragraph_index=match.paragraph_index,
+                        start=match.start,
+                        end=match.end,
+                        before=match.text,
+                        after=op.replacement,
+                    )
+                )
+
+        trace = trace_id or plan_id
+        record = PlanRecord(
+            plan_id=plan_id,
+            doc_id=doc_id,
+            trace_id=trace,
+            base_version=state.version,
+            diffs=all_diffs,
+            candidates=candidates,
+            unsafe=unsafe,
+            complexity_score=len(all_diffs),
+        )
+        self._plans[plan_id] = record
+        return record
+
+    def get_plan_record(self, plan_id: str) -> Optional[PlanRecord]:
+        return self._plans.get(plan_id)
+
+    def preview_plan_record(self, plan_id: str) -> PreviewRecord:
+        plan = self._plans.get(plan_id)
+        if plan is None:
+            raise PipelineError("PREVIEW_REQUIRED", "plan is not registered")
+        if plan.consumed:
+            raise PipelineError("PREVIEW_REQUIRED", "plan has already been applied")
+
+        state = self._documents.get(plan.doc_id)
+        if state is None:
+            raise PipelineError("MISSING_NODE", f"document '{plan.doc_id}' is not registered")
+        if state.version != plan.base_version:
+            raise PipelineError("CONFLICTING_TARGETS", "document has changed since planning")
+
+        if plan.unsafe:
+            raise PipelineError("UNSAFE_WILDCARD", "match count exceeds provided limit")
+        if plan.candidates:
+            raise PipelineError(
+                "AMBIGUOUS_TARGET",
+                "multiple matches require clarification",
+                candidates=[info.to_model() for info in plan.candidates],
+            )
+
+        diff_models = [
+            DiffPreview(
+                paragraphIndex=diff.paragraph_index,
+                before=diff.before,
+                after=diff.after,
+            )
+            for diff in plan.diffs
+        ]
+
+        preview = PreviewRecord(
+            plan_id=plan.plan_id,
+            doc_id=plan.doc_id,
+            diff_preview=diff_models,
+            complexity_score=plan.complexity_score,
+            safe=plan.safe,
+            trace_id=plan.trace_id,
+        )
+        self._previews[plan.plan_id] = preview
+        return preview
+
+    def apply_plan_record(
+        self,
+        plan_id: str,
+        *,
+        confirm: bool,
+        idempotency_key: Optional[str] = None,
+    ) -> ApplyData:
+        plan = self._plans.get(plan_id)
+        if plan is None:
+            raise PipelineError("PREVIEW_REQUIRED", "plan is not registered")
+
+        if idempotency_key:
+            try:
+                self._txn.ensure_idempotency(plan.doc_id, idempotency_key)
+            except IdempotentReplayError as exc:
+                raise PipelineError("IDEMPOTENT_REPLAY", str(exc)) from exc
+
+        if plan.consumed:
+            raise PipelineError("PREVIEW_REQUIRED", "plan has already been applied")
+
+        preview = self._previews.get(plan_id)
+        if preview is None:
+            raise PipelineError("PREVIEW_REQUIRED", "preview must be executed before apply")
+
+        state = self._documents.get(plan.doc_id)
+        if state is None:
+            raise PipelineError("MISSING_NODE", f"document '{plan.doc_id}' is not registered")
+        if state.version != plan.base_version:
+            raise PipelineError("CONFLICTING_TARGETS", "document has changed since planning")
+
+        if not confirm:
+            raise PipelineError("PREVIEW_REQUIRED", "confirm flag must be true")
+
+        snapshot = state.paragraphs()
+
+        def mutator(paragraphs: List[str]) -> List[str]:
+            working = paragraphs
+            for diff in plan.diffs:
+                working = diff.apply(working)
+            return working
+
+        def applier(paragraphs: List[str]) -> None:
+            state.set_content("\n".join(paragraphs))
+
+        self._txn.atomic(snapshot, mutator, applier)
+
+        if idempotency_key:
+            self._txn.record_idempotency(plan.doc_id, idempotency_key, {"planId": plan_id})
+
+        plan.consumed = True
+        self._previews.pop(plan_id, None)
+
+        return ApplyData(planId=plan.plan_id, applied=True)
+
+    # ------------------------------------------------------------------
+    # Searching and context helpers
+    # ------------------------------------------------------------------
+    def search_document(self, doc_id: str, params: SearchInput) -> List[SearchHit]:
+        state = self._documents.get(doc_id)
+        if state is None:
+            raise PipelineError("MISSING_NODE", f"document '{doc_id}' is not registered")
+        paragraphs = state.paragraphs()
+        hits = search_paragraphs(
+            paragraphs,
+            pattern=params.pattern,
+            limit=params.limit,
+            use_regex=params.is_regex,
+            node_resolver=state.node_for_index,
+        )
+        return hits
+
+    def context_window(self, doc_id: str, target: Target, *, window: int) -> ContextOutput:
+        state = self._documents.get(doc_id)
+        if state is None:
+            raise PipelineError("MISSING_NODE", f"document '{doc_id}' is not registered")
+        index = self._resolve_target_index(state, target)
+        paragraphs = state.paragraphs()
+        view = window_for_paragraph(paragraphs, index, radius=window)
+        return ContextOutput(**view)
+
+    # ------------------------------------------------------------------
+    # Response helpers
+    # ------------------------------------------------------------------
+    def plan_response(self, record: PlanRecord) -> Dict[str, object]:
+        data = ResponseData(
+            plan=PlanSummaryData(
+                planId=record.plan_id,
+                complexityScore=record.complexity_score,
+                safe=record.safe,
+                previewAvailable=not record.consumed,
+            )
+        )
+        actions = [
+            NextAction.model_validate(tools_meta.PLAN_NEXT_ACTION.render(record.plan_id))
+        ]
+        response = ServerResponse(
+            ok=True,
+            data=data,
+            nextActions=actions,
+            docVersion=self.doc_version(record.doc_id),
+            traceId=record.trace_id,
+        )
+        return response.model_dump(by_alias=True, exclude_none=True)
+
+    def preview_response(self, preview: PreviewRecord) -> Dict[str, object]:
+        data = ResponseData(
+            preview=PreviewData(
+                planId=preview.plan_id,
+                diff=preview.diff_preview,
+                complexityScore=preview.complexity_score,
+                safe=preview.safe,
+            )
+        )
+        actions = [
+            NextAction.model_validate(tools_meta.PREVIEW_NEXT_ACTION.render(preview.plan_id))
+        ]
+        response = ServerResponse(
+            ok=True,
+            data=data,
+            nextActions=actions,
+            docVersion=self.doc_version(preview.doc_id),
+            traceId=preview.trace_id,
+        )
+        return response.model_dump(by_alias=True, exclude_none=True)
+
+    def apply_response(self, plan: PlanRecord, result: ApplyData, trace_id: str) -> Dict[str, object]:
+        data = ResponseData(apply=result)
+        response = ServerResponse(
+            ok=True,
+            data=data,
+            nextActions=[],
+            docVersion=self.doc_version(plan.doc_id),
+            traceId=trace_id,
+        )
+        return response.model_dump(by_alias=True, exclude_none=True)
+
+    def error_response(
+        self,
+        doc_id: str,
+        trace_id: str,
+        error: PipelineError,
+        *,
+        plan_id: Optional[str] = None,
+        next_action: Optional[tools_meta.ExampleTemplate] = None,
+    ) -> Dict[str, object]:
+        actions: List[NextAction] = []
+        if next_action is not None:
+            rendered_plan = plan_id or "<plan-id>"
+            actions.append(NextAction.model_validate(next_action.render(rendered_plan)))
+        payload = ErrorPayload(
+            errorCode=error.error_code,
+            message=error.message,
+            candidates=error.candidates,
+            hint=error.hint,
+        )
+        response = ServerResponse(
+            ok=False,
+            error=payload,
+            nextActions=actions,
+            docVersion=self.doc_version(doc_id),
+            traceId=trace_id,
+        )
+        return response.model_dump(by_alias=True, exclude_none=True)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _find_matches(
+        self,
+        state: DocumentState,
+        paragraphs: Sequence[str],
+        op: ReplaceTextArgs,
+    ) -> List[ParagraphMatch]:
+        indices = self._resolve_scope(state, op.target, len(paragraphs))
+        matches: List[ParagraphMatch] = []
+        for index in indices:
+            paragraph = paragraphs[index]
+            start = 0
+            while True:
+                found = paragraph.find(op.match, start)
+                if found == -1:
+                    break
+                match = ParagraphMatch(
+                    paragraph_index=index,
+                    start=found,
+                    end=found + len(op.match),
+                    text=op.match,
+                )
+                matches.append(match)
+                start = found + len(op.match)
+        return matches
+
+    def _resolve_scope(
+        self,
+        state: DocumentState,
+        target: Target,
+        paragraph_count: int,
+    ) -> List[int]:
+        if target.node_id is not None:
+            index = state.index_for_node(target.node_id)
+            if index is None:
+                raise PipelineError("MISSING_NODE", f"node '{target.node_id}' not found")
+            return [index]
+        index = target.para_index or 0
+        if index < 0 or index >= paragraph_count:
+            raise PipelineError("RANGE_OUT_OF_BOUNDS", "paragraph index out of range")
+        return [index]
+
+    def _resolve_target_index(self, state: DocumentState, target: Target) -> int:
+        if target.node_id is not None:
+            index = state.index_for_node(target.node_id)
+            if index is None:
+                raise PipelineError("MISSING_NODE", f"node '{target.node_id}' not found")
+            return index
+        index = target.para_index or 0
+        paragraphs = len(state.paragraphs())
+        if index < 0 or index >= paragraphs:
+            raise PipelineError("RANGE_OUT_OF_BOUNDS", "paragraph index out of range")
+        return index

--- a/src/hwpx_mcp_server/core/txn.py
+++ b/src/hwpx_mcp_server/core/txn.py
@@ -1,0 +1,47 @@
+"""Transaction helpers for hardened editing pipeline."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Callable, Dict, Generic, TypeVar
+
+
+class TransactionError(RuntimeError):
+    """Base error for transaction handling."""
+
+
+class IdempotentReplayError(TransactionError):
+    """Raised when the same idempotency key is replayed."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(f"idempotency key '{key}' has already been processed")
+        self.key = key
+
+
+T = TypeVar("T")
+
+
+class TransactionManager(Generic[T]):
+    """Provide atomic execution and idempotency tracking."""
+
+    def __init__(self) -> None:
+        self._idempotency: Dict[str, Dict[str, Any]] = {}
+
+    def ensure_idempotency(self, scope: str, key: str) -> None:
+        token = self._token(scope, key)
+        if token in self._idempotency:
+            raise IdempotentReplayError(key)
+
+    def record_idempotency(self, scope: str, key: str, payload: Dict[str, Any]) -> None:
+        token = self._token(scope, key)
+        self._idempotency[token] = dict(payload)
+
+    def atomic(self, snapshot: T, mutator: Callable[[T], T], applier: Callable[[T], None]) -> T:
+        working_copy = copy.deepcopy(snapshot)
+        result = mutator(working_copy)
+        applier(result)
+        return result
+
+    @staticmethod
+    def _token(scope: str, key: str) -> str:
+        return f"{scope}::{key}"

--- a/src/hwpx_mcp_server/metadata/tools_meta.py
+++ b/src/hwpx_mcp_server/metadata/tools_meta.py
@@ -1,0 +1,39 @@
+"""Static metadata used for hardened tool responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class ExampleTemplate:
+    tool: str
+    example_json: str
+
+    def render(self, plan_id: str) -> Dict[str, str]:
+        return {
+            "tool": self.tool,
+            "exampleJson": self.example_json.replace("<plan-id>", plan_id),
+        }
+
+
+PLAN_NEXT_ACTION = ExampleTemplate(
+    tool="hwpx.preview_edit",
+    example_json='{"planId":"<plan-id>"}',
+)
+
+PREVIEW_NEXT_ACTION = ExampleTemplate(
+    tool="hwpx.apply_edit",
+    example_json='{"planId":"<plan-id>","confirm":true}',
+)
+
+APPLY_BAD_EXAMPLE = ExampleTemplate(
+    tool="hwpx.apply_edit",
+    example_json='{"planId":"<plan-id>"}',
+)
+
+ERROR_PREVIEW_REQUIRED = ExampleTemplate(
+    tool="hwpx.preview_edit",
+    example_json='{"planId":"<plan-id>"}',
+)

--- a/src/hwpx_mcp_server/schema/builder.py
+++ b/src/hwpx_mcp_server/schema/builder.py
@@ -1,0 +1,19 @@
+"""Helpers for constructing sanitized tool schemas."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Type
+
+from pydantic import BaseModel
+
+from .sanitizer import SchemaSanitizer
+
+
+def build_tool_schema(model: Type[BaseModel]) -> Dict[str, Any]:
+    """Return a sanitized JSON schema for the provided model."""
+
+    schema = model.model_json_schema(by_alias=True)
+    if not isinstance(schema, dict):  # pragma: no cover - defensive guard
+        raise TypeError("model_json_schema must return a mapping")
+    sanitizer = SchemaSanitizer(schema)
+    return sanitizer.sanitize()

--- a/src/hwpx_mcp_server/schema/sanitizer.py
+++ b/src/hwpx_mcp_server/schema/sanitizer.py
@@ -1,0 +1,299 @@
+"""Schema sanitizer ensuring draft-07 safe output."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class SchemaSanitizer:
+    """Normalize JSON schema produced by pydantic models."""
+
+    _DROP_KEYS = {
+        "$schema",
+        "$id",
+        "title",
+        "description",
+        "examples",
+        "default",
+    }
+    _FORBIDDEN_KEYS = {"$defs", "definitions", "if", "then", "else"}
+    _FORBIDDEN_PREFIXES = ("dependent", "unevaluated")
+
+    def __init__(self, schema: Dict[str, Any]):
+        if not isinstance(schema, dict):
+            raise TypeError("schema must be a mapping")
+        self._raw_schema = schema
+        self._ref_cache: Dict[str, Dict[str, Any]] = {}
+        self._resolving: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def sanitize(self) -> Dict[str, Any]:
+        sanitized, _ = self._sanitize_schema(self._raw_schema)
+        if not isinstance(sanitized, dict):
+            raise TypeError("sanitized schema must be a mapping")
+        sanitized.pop("$defs", None)
+        sanitized.pop("definitions", None)
+        sanitized = self._ensure_object_shape(sanitized)
+        return sanitized
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _sanitize_schema(self, node: Any) -> Tuple[Any, bool]:
+        if isinstance(node, dict):
+            working = dict(node)
+            optional = False
+
+            for key in list(working.keys()):
+                if key in self._DROP_KEYS or key in self._FORBIDDEN_KEYS:
+                    working.pop(key, None)
+                elif key.startswith(self._FORBIDDEN_PREFIXES):
+                    working.pop(key, None)
+
+            # allOf merging keeps flat schema objects
+            if "allOf" in working:
+                merged: Dict[str, Any] = {}
+                parts = working.pop("allOf")
+                if isinstance(parts, list):
+                    for part in parts:
+                        sanitized_part, part_optional = self._sanitize_schema(part)
+                        optional = optional or part_optional
+                        if isinstance(sanitized_part, dict):
+                            merged = self._merge_schema_dicts(merged, sanitized_part)
+                working = self._merge_schema_dicts(merged, working)
+
+            # Handle anyOf/oneOf optional unions
+            for union_key in ("anyOf", "oneOf"):
+                if union_key in working:
+                    options = working.pop(union_key)
+                    sanitized_options: List[Any] = []
+                    found_null = False
+                    if isinstance(options, list):
+                        for option in options:
+                            sanitized_option, opt_optional = self._sanitize_schema(option)
+                            optional = optional or opt_optional
+                            if self._is_null_schema(sanitized_option):
+                                found_null = True
+                            else:
+                                sanitized_options.append(sanitized_option)
+                    if not sanitized_options:
+                        working.pop("type", None)
+                    elif found_null and len(sanitized_options) == 1:
+                        base_schema = sanitized_options[0]
+                        if isinstance(base_schema, dict):
+                            working = self._merge_schema_dicts(working, base_schema)
+                        else:
+                            working = base_schema
+                        optional = True
+                    elif len(sanitized_options) == 1:
+                        base_schema = sanitized_options[0]
+                        if isinstance(base_schema, dict):
+                            working = self._merge_schema_dicts(working, base_schema)
+                        else:
+                            working = base_schema
+                    else:
+                        collapsed_type = self._collapse_simple_types(sanitized_options)
+                        if collapsed_type is not None:
+                            working["type"] = collapsed_type
+                        else:
+                            raise ValueError("complex schema unions are not supported")
+
+            if "$ref" in working:
+                ref = working.pop("$ref")
+                resolved = self._resolve_ref(ref)
+                working = self._merge_schema_dicts(resolved, working)
+
+            type_value = working.get("type")
+            if isinstance(type_value, list):
+                cleaned = [item for item in type_value if item != "null"]
+                if len(cleaned) != len(type_value):
+                    optional = True
+                if not cleaned:
+                    working.pop("type", None)
+                elif len(cleaned) == 1:
+                    working["type"] = cleaned[0]
+                else:
+                    raise ValueError("multiple primitive types are not supported")
+
+            if "const" in working:
+                const_value = working.pop("const")
+                if "enum" not in working:
+                    working["enum"] = [const_value]
+
+            optional_props: set[str] = set()
+            properties_value = working.get("properties")
+            if isinstance(properties_value, dict):
+                sanitized_properties: Dict[str, Any] = {}
+                for prop_name in sorted(properties_value.keys()):
+                    prop_schema = properties_value[prop_name]
+                    sanitized_prop, prop_optional = self._sanitize_schema(prop_schema)
+                    optional_props.update({prop_name} if prop_optional else set())
+                    sanitized_properties[prop_name] = sanitized_prop
+                working["properties"] = sanitized_properties
+            else:
+                working.pop("properties", None)
+
+            required_value = working.get("required")
+            required_items: List[str] = []
+            if isinstance(required_value, list):
+                seen: set[str] = set()
+                for item in required_value:
+                    if not isinstance(item, str):
+                        continue
+                    if item in optional_props or item in seen:
+                        continue
+                    seen.add(item)
+                    required_items.append(item)
+            required_items = sorted(required_items)
+            if required_items:
+                working["required"] = required_items
+            else:
+                working.pop("required", None)
+
+            for key, value in list(working.items()):
+                if key in {"properties", "required"}:
+                    continue
+                sanitized_value, child_optional = self._sanitize_schema(value)
+                optional = optional or child_optional
+                working[key] = sanitized_value
+
+            if self._is_object_schema(working):
+                working = self._ensure_object_shape(working)
+            else:
+                working.pop("required", None)
+
+            return working, optional
+
+        if isinstance(node, list):
+            sanitized_items: List[Any] = []
+            for item in node:
+                sanitized_item, _ = self._sanitize_schema(item)
+                sanitized_items.append(sanitized_item)
+            return sanitized_items, False
+
+        return node, False
+
+    def _collapse_simple_types(self, options: List[Any]) -> Optional[str]:
+        simple_types: List[str] = []
+        for option in options:
+            if not isinstance(option, dict):
+                return None
+            type_value = option.get("type")
+            if not isinstance(type_value, str):
+                return None
+            if len(option) > 1:
+                return None
+            simple_types.append(type_value)
+        if not simple_types:
+            return None
+        for preferred in ("string", "number", "integer", "boolean"):
+            if preferred in simple_types:
+                return preferred
+        return simple_types[0]
+
+    def _merge_schema_dicts(self, base: Dict[str, Any], overlay: Any) -> Dict[str, Any]:
+        if not isinstance(overlay, dict):
+            return self._clone(base)
+        result = self._clone(base)
+        for key, value in overlay.items():
+            if key == "properties" and isinstance(value, dict):
+                existing = result.get("properties")
+                if isinstance(existing, dict):
+                    merged = existing.copy()
+                    merged.update(value)
+                    result["properties"] = merged
+                else:
+                    result["properties"] = self._clone(value)
+            elif key == "required" and isinstance(value, list):
+                existing_required = result.get("required")
+                merged_required = []
+                if isinstance(existing_required, list):
+                    merged_required.extend(existing_required)
+                for item in value:
+                    if isinstance(item, str) and item not in merged_required:
+                        merged_required.append(item)
+                result["required"] = merged_required
+            else:
+                result[key] = self._clone(value)
+        return result
+
+    def _resolve_ref(self, ref: Any) -> Dict[str, Any]:
+        if not isinstance(ref, str):
+            raise TypeError("schema reference must be a string")
+        cached = self._ref_cache.get(ref)
+        if cached is not None:
+            return self._clone(cached)
+        if ref in self._resolving:
+            raise ValueError(f"circular schema reference detected for {ref}")
+        target = self._resolve_pointer(self._raw_schema, ref)
+        self._resolving.add(ref)
+        sanitized_target, _ = self._sanitize_schema(target)
+        self._resolving.remove(ref)
+        if not isinstance(sanitized_target, dict):
+            raise TypeError("referenced schema must resolve to a mapping")
+        self._ref_cache[ref] = sanitized_target
+        return self._clone(sanitized_target)
+
+    def _resolve_pointer(self, schema: Any, pointer: str) -> Any:
+        if pointer == "#":
+            return schema
+        if not pointer.startswith("#/"):
+            raise ValueError(f"unsupported schema reference: {pointer}")
+        parts = pointer[2:].split("/")
+        current = schema
+        for raw_part in parts:
+            part = raw_part.replace("~1", "/").replace("~0", "~")
+            if isinstance(current, dict):
+                if part not in current:
+                    raise KeyError(f"cannot resolve pointer {pointer}")
+                current = current[part]
+            elif isinstance(current, list):
+                index = int(part)
+                current = current[index]
+            else:
+                raise KeyError(f"cannot resolve pointer {pointer}")
+        return current
+
+    def _ensure_object_shape(self, schema: Dict[str, Any]) -> Dict[str, Any]:
+        result = dict(schema)
+        result["type"] = "object"
+        props = result.get("properties")
+        if not isinstance(props, dict):
+            props = {}
+        ordered_props = {key: props[key] for key in sorted(props.keys())}
+        result["properties"] = ordered_props
+        required = result.get("required")
+        if isinstance(required, list):
+            filtered = [item for item in required if isinstance(item, str)]
+        else:
+            filtered = []
+        result["required"] = sorted(dict.fromkeys(filtered))
+        result["additionalProperties"] = False
+        return result
+
+    def _clone(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {k: self._clone(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._clone(item) for item in value]
+        return value
+
+    @staticmethod
+    def _is_null_schema(schema: Any) -> bool:
+        return isinstance(schema, dict) and schema.get("type") == "null" and len(schema) == 1
+
+    @staticmethod
+    def _is_object_schema(schema: Dict[str, Any]) -> bool:
+        if not isinstance(schema, dict):
+            return False
+        if schema.get("type") == "object":
+            return True
+        if "properties" in schema:
+            return True
+        if "required" in schema:
+            return True
+        if "additionalProperties" in schema:
+            return True
+        return False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,80 @@
+import pytest
+
+from hwpx_mcp_server.core.plan import PlanManager, PipelineError
+
+
+def make_manager(paragraphs):
+    manager = PlanManager()
+    doc_id = "doc"
+    manager.register_document(doc_id, "\n".join(paragraphs))
+    return manager, doc_id
+
+
+def make_operation(match, replacement="UPDATED", *, section=0, paragraph=0, limit=1):
+    return {
+        "target": {
+            "section_index": section,
+            "para_index": paragraph,
+        },
+        "match": match,
+        "replacement": replacement,
+        "limit": limit,
+    }
+
+
+def test_apply_requires_preview():
+    manager, doc_id = make_manager(["alpha beta"])
+    record = manager.create_plan_record(doc_id, [make_operation("alpha")], trace_id="trace-apply")
+    with pytest.raises(PipelineError) as exc:
+        manager.apply_plan_record(record.plan_id, confirm=True)
+    assert exc.value.error_code == "PREVIEW_REQUIRED"
+
+
+def test_ambiguous_target_error():
+    manager, doc_id = make_manager(["target here target there"])
+    record = manager.create_plan_record(
+        doc_id,
+        [make_operation("target", replacement="TARGET", limit=5)],
+        trace_id="trace-ambiguous",
+    )
+    with pytest.raises(PipelineError) as exc:
+        manager.preview_plan_record(record.plan_id)
+    assert exc.value.error_code == "AMBIGUOUS_TARGET"
+    assert exc.value.candidates
+
+
+def test_limit_gate():
+    manager, doc_id = make_manager(["repeat repeat repeat"])
+    record = manager.create_plan_record(
+        doc_id,
+        [make_operation("repeat", limit=1)],
+        trace_id="trace-limit",
+    )
+    with pytest.raises(PipelineError) as exc:
+        manager.preview_plan_record(record.plan_id)
+    assert exc.value.error_code == "UNSAFE_WILDCARD"
+
+
+def test_idempotent_replay():
+    manager, doc_id = make_manager(["replace me once"])
+    record = manager.create_plan_record(doc_id, [make_operation("replace")], trace_id="trace-idem")
+    preview = manager.preview_plan_record(record.plan_id)
+    assert preview.plan_id == record.plan_id
+    result = manager.apply_plan_record(record.plan_id, confirm=True, idempotency_key="abc")
+    assert result.plan_id == record.plan_id
+    with pytest.raises(PipelineError) as exc:
+        manager.apply_plan_record(record.plan_id, confirm=True, idempotency_key="abc")
+    assert exc.value.error_code == "IDEMPOTENT_REPLAY"
+
+
+def test_atomic_rollback_preserves_document():
+    manager, doc_id = make_manager(["original text"])
+    record = manager.create_plan_record(doc_id, [make_operation("original")], trace_id="trace-atomic")
+    manager.preview_plan_record(record.plan_id)
+    manager.replace_document(doc_id, "tampered text")
+    original_version = manager.doc_version(doc_id)
+    with pytest.raises(PipelineError) as exc:
+        manager.apply_plan_record(record.plan_id, confirm=True)
+    assert exc.value.error_code == "CONFLICTING_TARGETS"
+    assert manager.get_document_text(doc_id) == "tampered text"
+    assert manager.doc_version(doc_id) == original_version

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,43 @@
+import pytest
+
+from hwpx_mcp_server.tools import build_tool_definitions
+
+BANNED_KEYS = {"$defs", "definitions", "$ref", "anyOf", "oneOf", "allOf", "if", "then", "else", "const"}
+
+
+def _assert_object_shape(schema: dict) -> None:
+    assert schema.get("type") == "object"
+    assert "properties" in schema and isinstance(schema["properties"], dict)
+    assert schema.get("additionalProperties") is False
+    assert "required" in schema and isinstance(schema["required"], list)
+    prop_keys = list(schema["properties"].keys())
+    assert prop_keys == sorted(prop_keys)
+    assert schema["required"] == sorted(schema["required"])
+
+
+def _walk(node):
+    if isinstance(node, dict):
+        for key in BANNED_KEYS:
+            assert key not in node
+        type_value = node.get("type")
+        if isinstance(type_value, list):
+            assert "null" not in type_value
+        if node.get("type") == "object" or "properties" in node:
+            _assert_object_shape(node)
+        for value in node.values():
+            _walk(value)
+    elif isinstance(node, list):
+        for item in node:
+            _walk(item)
+
+
+@pytest.mark.parametrize("flag", ["0", "1"])
+def test_tool_schemas_are_sanitized(monkeypatch, flag):
+    monkeypatch.setenv("HWPX_MCP_HARDENING", flag)
+    definitions = build_tool_definitions()
+    for definition in definitions:
+        tool = definition.to_tool()
+        _walk(tool.inputSchema)
+        _walk(tool.outputSchema)
+        assert tool.inputSchema.get("type") == "object"
+        assert tool.outputSchema.get("type") == "object"


### PR DESCRIPTION
## Summary
- add a draft-07 compliant schema sanitizer/builder and route all tool JSON schema generation through it
- introduce a hardened plan/preview/apply pipeline plus search/context helpers, exposed only when `HWPX_MCP_HARDENING=1`
- extend the MCP ops wiring and tool catalogue to surface the new helpers and response envelopes
- add schema regression and pipeline guardrail tests to ensure future safety checks stick

## Motivation
- prevent schema regressions that break downstream tool ingestion and ensure hardened edit flows stay behind an explicit feature flag

## Usage
- enable hardened helpers by exporting `HWPX_MCP_HARDENING=1` before starting the server
- use existing behaviour unchanged when the flag is unset (default)

## Testing
- `pytest -q`

## Rollback
- disable the feature flag (`HWPX_MCP_HARDENING=0`) to fall back to legacy tooling while investigating


------
https://chatgpt.com/codex/tasks/task_e_68d1f16b6d6c8329abe0f1174f6241ba