### PR TITLE
Add auto-fit table column support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ uvx hwpx-mcp-server
 }
 ```
 
-`set_table_cell_text`와 `replace_table_region`은 선택적인 `logical`/`splitMerged` 플래그를 지원합니다. `logical: true`로 지정하면 방금 확인한 논리 좌표계를 그대로 사용할 수 있고, `splitMerged: true`를 함께 전달하면 쓰기 전에 자동으로 해당 병합 영역을 분할합니다. 병합을 직접 해제해야 할 때는 `split_table_cell` 도구가 원래 범위를 알려주면서 셀을 분할합니다.
+`set_table_cell_text`와 `replace_table_region`은 선택적인 `logical`/`splitMerged` 플래그를 지원합니다. `logical: true`로 지정하면 방금 확인한 논리 좌표계를 그대로 사용할 수 있고, `splitMerged: true`를 함께 전달하면 쓰기 전에 자동으로 해당 병합 영역을 분할합니다. 긴 텍스트를 채울 때는 `autoFit: true`를 추가로 지정하면 각 열 너비가 셀 내용 길이에 맞춰 다시 계산되어 표 전체 폭(`hp:sz`)과 셀 크기(`hp:cellSz`)가 함께 업데이트됩니다. 병합을 직접 해제해야 할 때는 `split_table_cell` 도구가 원래 범위를 알려주면서 셀을 분할합니다.
 
 ```jsonc
 {
@@ -201,6 +201,7 @@ uvx hwpx-mcp-server
     "text": "논리 좌표 편집",
     "logical": true,
     "splitMerged": true,
+    "autoFit": true,
     "dryRun": false
   }
 }

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -188,6 +188,7 @@ class AddTableInput(PathInput):
     border_color: Optional[str] = Field(None, alias="borderColor")
     border_width: Optional[str | float | int] = Field(None, alias="borderWidth")
     fill_color: Optional[str] = Field(None, alias="fillColor")
+    auto_fit: bool = Field(False, alias="autoFit")
 
 
 class AddTableOutput(_BaseModel):
@@ -240,6 +241,7 @@ class SetTableCellInput(PathInput):
     logical: Optional[bool] = Field(None, alias="logical")
     split_merged: Optional[bool] = Field(None, alias="splitMerged")
     dry_run: bool = Field(False, alias="dryRun")
+    auto_fit: bool = Field(False, alias="autoFit")
 
 
 class SetTableCellOutput(_BaseModel):
@@ -254,6 +256,7 @@ class ReplaceTableRegionInput(PathInput):
     logical: Optional[bool] = Field(None, alias="logical")
     split_merged: Optional[bool] = Field(None, alias="splitMerged")
     dry_run: bool = Field(False, alias="dryRun")
+    auto_fit: bool = Field(False, alias="autoFit")
 
 
 class ReplaceTableRegionOutput(_BaseModel):


### PR DESCRIPTION
## Summary
- add an auto-fit helper that resizes table columns based on cell text and wire it into table creation and editing operations
- expose the new `autoFit` flag through the MCP tool schemas and document how to use it
- cover the workflow with new unit tests for single-cell updates and bulk replacements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d47b77db34832989eba11171b10307