### PR TITLE
Fix insert_paragraphs_bulk dry-run behavior

### DIFF
--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -861,10 +861,14 @@ class HwpxOps:
         *,
         section_index: Optional[int] = None,
         run_style: Optional[Dict[str, Any]] = None,
-        dry_run: bool = True,
+        dry_run: bool = False,
     ) -> Dict[str, Any]:
         if not paragraphs:
             return {"added": 0}
+
+        if dry_run:
+            return {"added": len(paragraphs)}
+
         document, resolved = self._open_document(path)
         char_id = self._ensure_char_style(document, run_style)
         count = 0
@@ -875,8 +879,7 @@ class HwpxOps:
                 char_pr_id_ref=char_id,
             )
             count += 1
-        if not dry_run:
-            self._save_document(document, resolved)
+        self._save_document(document, resolved)
         return {"added": count}
 
     def add_table(

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -173,7 +173,7 @@ class InsertParagraphsInput(PathInput):
     section_index: Optional[int] = Field(None, alias="sectionIndex")
     paragraphs: Sequence[str]
     run_style: Optional[RunStyleModel] = Field(None, alias="runStyle")
-    dry_run: bool = Field(True, alias="dryRun")
+    dry_run: bool = Field(False, alias="dryRun")
 
 
 class InsertParagraphsOutput(_BaseModel):


### PR DESCRIPTION
## Summary
- default the insert_paragraphs_bulk tool to persist changes unless dryRun is explicitly enabled
- skip document mutation entirely during dry runs and always save when applying bulk paragraph inserts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a455a4688329a5d89a7e8b761292