### PR TITLE
Add document locator union schema and update tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,55 @@ uvx hwpx-mcp-server
 
 > 🔐 `HWPX_MCP_HARDENING=1`로 실행하면 새 편집 파이프라인(`plan → preview → apply`)과 검색/컨텍스트 도구가 함께 노출됩니다. 값이 `0` 또는 미설정이면 기존 도구 표면만 유지됩니다.
 
+### 📁 문서 로케이터(Document Locator)
+
+모든 도구의 입력은 이제 문서를 가리키는 **discriminated union** 로케이터를 사용합니다. 기본값은 기존과 동일하게 상위 수준의 `path` 필드이며, 별도 선언 없이도 계속 사용할 수 있습니다. 필요에 따라 명시적으로 `type`을 지정해 HTTP 백엔드나 사전 등록된 핸들을 사용할 수 있습니다.
+
+- **로컬 파일 (기존 스키마와 동일)**
+
+  ```jsonc
+  {
+    "name": "open_info",
+    "arguments": {
+      "path": "sample.hwpx"
+    }
+  }
+  ```
+
+- **HTTP 백엔드와 연계** — 서버를 HTTP 스토리지 모드로 실행한 경우, 원격 경로를 `uri` 필드로 지정하고 필요 시 `backend` 힌트를 제공할 수 있습니다.
+
+  ```jsonc
+  {
+    "name": "open_info",
+    "arguments": {
+      "type": "uri",
+      "uri": "reports/weekly.hwpx",
+      "backend": "http"
+    }
+  }
+  ```
+
+- **사전 등록된 핸들 사용** — 하드닝 파이프라인에서 이미 로드된 문서에 대해 후속 검색/컨텍스트/편집을 수행할 때는 `handleId`를 전달하면 됩니다.
+
+  ```jsonc
+  {
+    "name": "hwpx.plan_edit",
+    "arguments": {
+      "type": "handle",
+      "handleId": "doc-1234",
+      "operations": [
+        {
+          "target": {"nodeId": "n_deadbeef"},
+          "match": "needle",
+          "replacement": "haystack"
+        }
+      ]
+    }
+  }
+  ```
+
+각 변형은 필요에 따라 `backend` 필드를 추가로 가질 수 있으며, 명시적으로 `document` 객체를 중첩하여 전달하는 것도 허용됩니다. 스키마는 Sanitizer를 거쳐 `$ref` 없이 평탄화된 형태로 제공됩니다.
+
 ### 🔐 하드닝 편집 파이프라인 (옵션)
 
 하드닝 플래그를 켜면 모든 편집 요청이 **계획(Plan) → 검토(Preview) → 적용(Apply)**의 3단계를 거치도록 설계된 신규 도구가 함께 노출됩니다. 하드닝 플래그는 저렴한 LLM 모델의 요청에도 성공적인 작업을 수행하기 위해서 도입한 테스트중인 기능입니다. 

--- a/docs/hardening_guide_ko.md
+++ b/docs/hardening_guide_ko.md
@@ -17,6 +17,8 @@
 | Preview | `hwpx.preview_edit` | `planId`를 검증하면서 diff, 모호성 후보, 안전 점수를 제공합니다. 이 기록이 없으면 Apply 단계로 이동할 수 없습니다. |
 | Apply | `hwpx.apply_edit` | `confirm: true`와 함께 요청해야 하며, 미리보기한 동일한 `planId`만 허용됩니다. `idempotencyKey`를 지정하면 재시도 시 안전하게 무시됩니다. |
 
+> 📌 모든 하드닝 도구는 공통 `document` 로케이터 스키마를 사용합니다. 기존 `path` 값을 그대로 전달해도 되지만, 이미 로드된 문서를 후속 요청에서 재사용하려면 `{"type": "handle", "handleId": "..."}` 형태로 안정적인 식별자를 전달하는 것이 좋습니다. HTTP 백엔드를 사용할 때는 `{"type": "uri", "uri": "...", "backend": "http"}`와 같이 명시적으로 지정할 수 있습니다.
+
 ### 오류 코드 요약
 | 코드 | 의미 | 대응 |
 | --- | --- | --- |

--- a/src/hwpx_mcp_server/core/locator.py
+++ b/src/hwpx_mcp_server/core/locator.py
@@ -1,0 +1,152 @@
+"""Document locator models used across tool schemas."""
+
+from __future__ import annotations
+
+from typing import Annotated, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Literal
+
+
+_LOCATOR_KEYS = {"type", "path", "uri", "backend", "handleId"}
+
+
+class _LocatorModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class PathLocator(_LocatorModel):
+    type: Literal["path"] = Field("path", alias="type")
+    path: str
+    backend: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_type(cls, data: object) -> object:
+        if isinstance(data, dict) and "type" not in data and "path" in data:
+            enriched = dict(data)
+            enriched.setdefault("type", "path")
+            return enriched
+        return data
+
+
+class UriLocator(_LocatorModel):
+    type: Literal["uri"] = Field("uri", alias="type")
+    uri: str
+    backend: Optional[str] = None
+
+
+class HandleLocator(_LocatorModel):
+    type: Literal["handle"] = Field("handle", alias="type")
+    handle_id: str = Field(alias="handleId")
+    backend: Optional[str] = None
+
+
+DocumentLocator = Annotated[
+    PathLocator | UriLocator | HandleLocator,
+    Field(discriminator="type"),
+]
+
+
+def normalize_locator_payload(data: Dict[str, object], *, field_name: str = "document") -> Dict[str, object]:
+    """Return *data* with locator keys grouped under *field_name*.
+
+    The function accepts legacy payloads that specify ``path`` at the top level
+    while also supporting fully qualified discriminated union inputs.
+    """
+
+    if field_name in data:
+        return data
+
+    locator: Dict[str, object] = {}
+    remainder: Dict[str, object] = {}
+    for key, value in data.items():
+        if key in _LOCATOR_KEYS:
+            locator[key] = value
+        else:
+            remainder[key] = value
+
+    if not locator:
+        raise ValueError("document locator must include path, uri, or handleId")
+
+    if "type" not in locator:
+        if "path" in locator:
+            locator["type"] = "path"
+        elif "uri" in locator:
+            locator["type"] = "uri"
+        elif "handleId" in locator:
+            locator["type"] = "handle"
+        else:  # pragma: no cover - defensive guard
+            raise ValueError("document locator requires a discriminator")
+
+    remainder[field_name] = locator
+    return remainder
+
+
+def locator_identifier(locator: DocumentLocator) -> str:
+    """Return a stable identifier for *locator*."""
+
+    if isinstance(locator, PathLocator):
+        return locator.path
+    if isinstance(locator, UriLocator):
+        return locator.uri
+    if isinstance(locator, HandleLocator):
+        return locator.handle_id
+    raise TypeError(f"Unsupported locator type: {type(locator)!r}")
+
+
+def locator_path(locator: DocumentLocator) -> Optional[str]:
+    """Return the preferred path-like value for *locator* if available."""
+
+    if isinstance(locator, PathLocator):
+        return locator.path
+    if isinstance(locator, UriLocator):
+        return locator.uri
+    return None
+
+
+def locator_backend(locator: DocumentLocator) -> Optional[str]:
+    """Return the backend hint provided by *locator*, if any."""
+
+    return getattr(locator, "backend", None)
+
+
+def document_locator_schema() -> Dict[str, object]:
+    """Return a sanitized JSON schema fragment for document locators."""
+
+    return {
+        "type": "object",
+        "description": (
+            "Discriminated locator supporting legacy paths, HTTP URIs, or opaque handles. "
+            "Top-level path/uri/handleId shorthands remain supported for backwards compatibility."
+        ),
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": ["path", "uri", "handle"],
+                "description": "Locator variant; defaults to 'path' when omitted.",
+            },
+            "path": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Filesystem-relative path resolved by the configured storage backend.",
+            },
+            "uri": {
+                "type": "string",
+                "minLength": 1,
+                "description": "HTTP or backend-specific URI when using remote storage.",
+            },
+            "handleId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Opaque identifier for a previously registered document handle.",
+            },
+            "backend": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional hint describing the storage backend to use (e.g. 'http').",
+            },
+        },
+        "required": ["type"],
+        "additionalProperties": False,
+    }

--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -1618,10 +1618,10 @@ class HwpxOps:
         trace = payload.trace_id or f"plan-{uuid4().hex}"
         try:
             record = self._plan_manager.create_plan_record(
-                payload.path, payload.operations, trace_id=trace
+                payload.doc_id, payload.operations, trace_id=trace
             )
         except PipelineError as error:
-            return self._plan_manager.error_response(payload.path, trace, error)
+            return self._plan_manager.error_response(payload.doc_id, trace, error)
         return self._plan_manager.plan_response(record)
 
     def preview_edit(
@@ -1702,7 +1702,7 @@ class HwpxOps:
             }
         )
         try:
-            hits = self._plan_manager.search_document(payload.path, payload)
+            hits = self._plan_manager.search_document(payload.doc_id, payload)
         except PipelineError as error:
             raise HwpxOperationError(error.message) from error
         models = [
@@ -1728,7 +1728,7 @@ class HwpxOps:
         )
         try:
             view = self._plan_manager.context_window(
-                payload.path, payload.target, window=payload.window
+                payload.doc_id, payload.target, window=payload.window
             )
         except PipelineError as error:
             raise HwpxOperationError(error.message) from error

--- a/tests/test_locator_models.py
+++ b/tests/test_locator_models.py
@@ -1,0 +1,41 @@
+import pytest
+
+from hwpx_mcp_server.core.plan import PlanEditInput
+from hwpx_mcp_server.tools import DocumentLocatorInput
+
+
+def test_document_locator_input_accepts_legacy_path() -> None:
+    payload = DocumentLocatorInput.model_validate({"path": "sample.hwpx"})
+    assert payload.to_hwpx_payload() == {"path": "sample.hwpx"}
+
+
+def test_document_locator_input_accepts_uri_variant() -> None:
+    uri = "https://example.com/sample.hwpx"
+    payload = DocumentLocatorInput.model_validate({"type": "uri", "uri": uri, "backend": "http"})
+    data = payload.to_hwpx_payload()
+    assert data["path"] == uri
+
+
+def test_document_locator_handle_requires_explicit_opt_in() -> None:
+    payload = DocumentLocatorInput.model_validate({"type": "handle", "handleId": "doc-123"})
+    with pytest.raises(ValueError):
+        payload.to_hwpx_payload()
+    assert payload.to_hwpx_payload(require_path=False) == {}
+
+
+def test_plan_edit_input_surface_doc_id_for_handle() -> None:
+    payload = PlanEditInput.model_validate(
+        {
+            "type": "handle",
+            "handleId": "registered-doc",
+            "operations": [
+                {
+                    "target": {"nodeId": "n_deadbeef"},
+                    "match": "needle",
+                    "replacement": "haystack",
+                }
+            ],
+        }
+    )
+    assert payload.doc_id == "registered-doc"
+    assert payload.to_hwpx_payload(require_path=False)["operations"]

--- a/tests/test_mcp_end_to_end.py
+++ b/tests/test_mcp_end_to_end.py
@@ -766,7 +766,10 @@ def test_tool_json_schemas_use_json_schema_2020_12(
     package_get_text = generated["package_get_text"].inputSchema
     encoding_schema = package_get_text["properties"]["encoding"]
     assert encoding_schema == {"type": "string"}
-    assert set(package_get_text["required"]) == {"path", "partName"}
+    assert set(package_get_text["required"]) == {"document", "partName"}
+    document_schema = package_get_text["properties"]["document"]
+    assert document_schema["type"] == "object"
+    assert "type" in document_schema["properties"]
 
     find_runs_input = generated["find_runs_by_style"].inputSchema
     filters_schema = find_runs_input["properties"]["filters"]
@@ -780,7 +783,7 @@ def test_tool_json_schemas_use_json_schema_2020_12(
     assert filters_schema["properties"]["underline"]["type"] == "boolean"
     assert filters_schema["properties"]["charPrIDRef"]["type"] == "string"
     assert "filters" not in find_runs_input.get("required", [])
-    assert "path" in find_runs_input.get("required", [])
+    assert "document" in find_runs_input.get("required", [])
 
     find_runs_output = generated["find_runs_by_style"].outputSchema
     runs_schema = find_runs_output["properties"]["runs"]
@@ -796,17 +799,17 @@ def test_tool_json_schemas_use_json_schema_2020_12(
     assert style_filter_schema["properties"]["underline"]["type"] == "boolean"
     assert "styleFilter" not in replace_runs_input.get("required", [])
     required_fields = set(replace_runs_input.get("required", []))
-    assert {"path", "search", "replacement"}.issubset(required_fields)
+    assert {"document", "search", "replacement"}.issubset(required_fields)
 
     add_paragraph_input = generated["add_paragraph"].inputSchema
     run_style_schema = add_paragraph_input["properties"]["runStyle"]
     assert run_style_schema["type"] == "object"
     assert run_style_schema["properties"]["bold"]["type"] == "boolean"
     assert "runStyle" not in add_paragraph_input.get("required", [])
-    assert "path" in add_paragraph_input.get("required", [])
+    assert "document" in add_paragraph_input.get("required", [])
 
     read_paragraphs_input = generated["read_paragraphs"].inputSchema
-    assert {"path", "paragraphIndexes"}.issubset(
+    assert {"document", "paragraphIndexes"}.issubset(
         set(read_paragraphs_input.get("required", []))
     )
     paragraph_indexes = read_paragraphs_input["properties"]["paragraphIndexes"]
@@ -823,7 +826,7 @@ def test_tool_json_schemas_use_json_schema_2020_12(
     add_memo_with_anchor_input = generated["add_memo_with_anchor"].inputSchema
     memo_anchor_props = add_memo_with_anchor_input["properties"]
     assert memo_anchor_props["memoShapeIdRef"] == {"type": "string"}
-    assert {"path", "text"}.issubset(
+    assert {"document", "text"}.issubset(
         set(add_memo_with_anchor_input.get("required", []))
     )
     assert "memoShapeIdRef" not in add_memo_with_anchor_input.get("required", [])


### PR DESCRIPTION
## Summary
- introduce a shared `DocumentLocator` union and wire it through tool inputs and hardened plan/search models
- extend HwpxOps helpers and documentation to work with the new locator variants and describe HTTP/handle usage
- add validation coverage for each locator form and adjust schema expectations accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc74b387e88329b109b9de9b49a261