### PR TITLE
Default replace_text_in_runs to perform writes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ uvx hwpx-mcp-server
       - `hwpx.search` *(플래그 활성 시)*: 정규식/키워드 검색과 안정적인 노드 식별자 반환
       - `hwpx.get_context` *(플래그 활성 시)*: 문단 전후 문맥만 제한적으로 조회
   - **문서 편집**
-      - `replace_text_in_runs`: 스타일을 보존하며 텍스트 치환
+      - `replace_text_in_runs`: 스타일을 보존하며 텍스트 치환 (기본적으로 문서를 저장하므로,
+        미리보기만 원하면 `dryRun: true`를 지정하세요.)
       - `add_paragraph`, `insert_paragraphs_bulk`: 문단 추가
       - `add_table`, `get_table_cell_map`, `set_table_cell_text`, `replace_table_region`, `split_table_cell`: 표 생성·편집 및 병합 해제
       - `add_shape`, `add_control`: 개체 추가

--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -801,7 +801,7 @@ class HwpxOps:
         *,
         style_filter: Optional[Dict[str, Any]] = None,
         limit_per_run: Optional[int] = None,
-        dry_run: bool = True,
+        dry_run: bool = False,
     ) -> Dict[str, Any]:
         document, resolved = self._open_document(path)
         filter_args: Dict[str, Any] = {}

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -176,7 +176,7 @@ class ReplaceRunsInput(DocumentLocatorInput):
     replacement: str
     style_filter: Optional[StyleFilter] = Field(None, alias="styleFilter")
     limit_per_run: Optional[int] = Field(None, alias="limitPerRun")
-    dry_run: bool = Field(True, alias="dryRun")
+    dry_run: bool = Field(False, alias="dryRun")
 
 
 class ReplaceRunsOutput(_BaseModel):


### PR DESCRIPTION
## Summary
- default the replace_text_in_runs tool and HwpxOps helper to run with dryRun disabled
- update the public README entry to explain the new default behavior

## Testing
- pytest tests/test_hwpx_ops.py::test_replace_text_in_runs_updates_file_and_backup tests/test_mcp_end_to_end.py::test_replace_text_in_runs_respects_dry_run

------
https://chatgpt.com/codex/tasks/task_e_68de6895351c832990f2fbe0dbb8ae61