### PR TITLE
Ensure planner documents are registered before plan operations

### DIFF
--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -202,6 +202,29 @@ def test_replace_text_in_runs_dry_run_does_not_modify(ops_with_sample):
     assert "DOCX" not in text
 
 
+def test_planning_flow_registers_document(ops_with_sample):
+    ops, path = ops_with_sample
+    operations = [
+        {
+            "target": {"sectionIndex": 0, "paraIndex": 1},
+            "match": "Hello HWPX!",
+            "replacement": "Hello HWPX!",
+            "dryRun": True,
+        }
+    ]
+
+    plan_result = ops.plan_edit(path=str(path), operations=operations)
+    assert plan_result.get("ok") is True
+
+    search_result = ops.search(path=str(path), pattern="HWPX")
+    assert search_result["matches"], "Expected at least one search match"
+
+    context_result = ops.get_context(
+        path=str(path), target={"sectionIndex": 0, "paraIndex": 1}
+    )
+    assert context_result["focus"].startswith("Hello HWPX!")
+
+
 def test_replace_text_in_runs_updates_file_and_backup(ops_with_sample):
     ops, path = ops_with_sample
     ops.replace_text_in_runs(str(path), "HWPX", "DOCX", dry_run=False)


### PR DESCRIPTION
## Summary
- add a helper to refresh planner document content using the text extractor
- call the helper from plan_edit, search, and get_context before delegating to the planner
- cover the hardened planning flow with an integration-style test using the sample document

## Testing
- pytest tests/test_hwpx_ops.py

------
https://chatgpt.com/codex/tasks/task_e_68de763941d88329a67414836b34eba1