### PR TITLE
Preserve tool schema additionalProperties for OpenInfoOutput meta

### DIFF
--- a/src/hwpx_mcp_server/schema/sanitizer.py
+++ b/src/hwpx_mcp_server/schema/sanitizer.py
@@ -270,7 +270,10 @@ class SchemaSanitizer:
         else:
             filtered = []
         result["required"] = sorted(dict.fromkeys(filtered))
-        result["additionalProperties"] = False
+        if "additionalProperties" in schema:
+            result["additionalProperties"] = self._clone(schema["additionalProperties"])
+        else:
+            result["additionalProperties"] = False
         return result
 
     def _clone(self, value: Any) -> Any:

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,6 +1,8 @@
+import jsonschema
 import pytest
 
-from hwpx_mcp_server.tools import build_tool_definitions
+from hwpx_mcp_server.schema.builder import build_tool_schema
+from hwpx_mcp_server.tools import OpenInfoOutput, build_tool_definitions
 
 BANNED_KEYS = {"$defs", "definitions", "$ref", "anyOf", "oneOf", "allOf", "if", "then", "else", "const"}
 
@@ -8,7 +10,9 @@ BANNED_KEYS = {"$defs", "definitions", "$ref", "anyOf", "oneOf", "allOf", "if", 
 def _assert_object_shape(schema: dict) -> None:
     assert schema.get("type") == "object"
     assert "properties" in schema and isinstance(schema["properties"], dict)
-    assert schema.get("additionalProperties") is False
+    assert "additionalProperties" in schema
+    additional = schema["additionalProperties"]
+    assert isinstance(additional, (bool, dict))
     assert "required" in schema and isinstance(schema["required"], list)
     prop_keys = list(schema["properties"].keys())
     assert prop_keys == sorted(prop_keys)
@@ -41,3 +45,23 @@ def test_tool_schemas_are_sanitized(monkeypatch, flag):
         _walk(tool.outputSchema)
         assert tool.inputSchema.get("type") == "object"
         assert tool.outputSchema.get("type") == "object"
+
+
+def test_open_info_meta_allows_additional_properties():
+    schema = build_tool_schema(OpenInfoOutput)
+    meta_schema = schema["properties"]["meta"]
+    assert meta_schema["additionalProperties"]
+
+    sample = {
+        "meta": {
+            "path": "document.hwpx",
+            "absolutePath": "/tmp/document.hwpx",
+            "size": 42,
+            "modified": "2024-01-01T00:00:00",
+        },
+        "sectionCount": 3,
+        "paragraphCount": 10,
+        "headerCount": 1,
+    }
+
+    jsonschema.validate(sample, schema)


### PR DESCRIPTION
## Summary
- retain existing `additionalProperties` flags when normalizing object schemas so permissive fields stay permissive
- adjust schema tests and add a regression validating that the `open_info` meta payload accepts metadata keys

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de7b8cd5388329a5c70a5f0464a4b7