### PR TITLE
Ensure tool responses omit null optional fields

### DIFF
--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -493,7 +493,9 @@ class ToolDefinition:
     def call(self, ops: HwpxOps, arguments: Dict[str, Any]) -> Dict[str, Any]:
         data = self.input_model.model_validate(arguments)
         raw = self.func(ops, data)
-        return self.output_model.model_validate(raw).model_dump(by_alias=True)
+        return self.output_model.model_validate(raw).model_dump(
+            by_alias=True, exclude_none=True
+        )
 
 
 def _simple(

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -93,6 +93,24 @@ def test_read_text_uses_default_limit(monkeypatch, tmp_path):
     assert expanded["nextOffset"] == expanded_limit
 
 
+def test_read_text_tool_omits_next_offset_when_complete(ops_with_sample):
+    ops, path = ops_with_sample
+    read_text_tool = next(
+        tool for tool in build_tool_definitions() if tool.name == "read_text"
+    )
+
+    result = read_text_tool.call(
+        ops,
+        {
+            "path": str(path),
+            "limit": 10_000,
+        },
+    )
+
+    assert result["textChunk"]
+    assert "nextOffset" not in result
+
+
 def test_read_text_consumes_only_requested_slice(monkeypatch, tmp_path):
     class TrackingParagraph:
         def __init__(self, index: int) -> None:

--- a/tests/test_mcp_end_to_end.py
+++ b/tests/test_mcp_end_to_end.py
@@ -572,7 +572,8 @@ def test_shape_control_and_memo_tools(
         path=rel_path,
         dryRun=False,
     )
-    assert "objectId" in shape_result
+    if "objectId" in shape_result:
+        assert shape_result["objectId"]
     assert _count_tag(doc_path, f"{HP_NS}RECTANGLE") == original_shape_count + 1
 
     original_ctrl = _count_controls(doc_path, "TEXTBOX")
@@ -584,7 +585,8 @@ def test_shape_control_and_memo_tools(
         controlType="TEXTBOX",
         dryRun=False,
     )
-    assert "objectId" in control_result
+    if "objectId" in control_result:
+        assert control_result["objectId"]
     assert _count_controls(doc_path, "TEXTBOX") == original_ctrl + 1
 
     memo_result = _call(


### PR DESCRIPTION
## Summary
- update ToolDefinition.call to drop None-valued optional fields when serializing
- add pagination regression test covering end-of-document behavior
- relax optional object ID assertions in end-to-end tool tests after serialization change

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de833625688329af08ed998a02021f