### PR TITLE
feat: add `add_table_rows` tool for dynamic table row insertion

### DIFF
--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -307,6 +307,36 @@ class SplitTableCellOutput(_BaseModel):
     colSpan: int
 
 
+class AddTableRowsInput(DocumentLocatorInput):
+    """Input model for adding rows to an existing table."""
+    table_index: int = Field(alias="tableIndex", description="Zero-based index of the target table")
+    count: int = Field(1, ge=1, description="Number of rows to add")
+    position: Optional[int] = Field(
+        None,
+        ge=0,
+        description="Row index after which to insert. None=append at end, 0=insert before first row"
+    )
+    copy_style_from: Optional[int] = Field(
+        None,
+        alias="copyStyleFrom",
+        ge=0,
+        description="Row index to copy cell styles from. None=use last row"
+    )
+    values: Optional[Sequence[Sequence[str]]] = Field(
+        None,
+        description="2D list of cell values. Length must match count parameter"
+    )
+    dry_run: bool = Field(False, alias="dryRun", description="If true, validate without saving")
+
+
+class AddTableRowsOutput(_BaseModel):
+    """Output model for add_table_rows operation."""
+    addedRows: int
+    totalRows: int
+    insertedAfter: Optional[int] = None
+    expandedSpanCells: int = 0
+
+
 class AddShapeInput(DocumentLocatorInput):
     shape_type: str = Field("RECTANGLE", alias="shapeType")
     section_index: Optional[int] = Field(None, alias="sectionIndex")
@@ -652,6 +682,13 @@ def build_tool_definitions() -> List[ToolDefinition]:
             input_model=SplitTableCellInput,
             output_model=SplitTableCellOutput,
             func=_simple("split_table_cell"),
+        ),
+        ToolDefinition(
+            name="add_table_rows",
+            description="Add one or more rows to an existing table. Copies cell styles from a specified row (default: last row). Supports inserting at specific positions and initializing with values.",
+            input_model=AddTableRowsInput,
+            output_model=AddTableRowsOutput,
+            func=_simple("add_table_rows"),
         ),
         ToolDefinition(
             name="add_shape",


### PR DESCRIPTION
## feat: `add add_table_rows` tool for dynamic table row insertion

### 개요
기존 테이블에 동적으로 행을 추가하는 `add_table_rows` 메서드 구현

### 주요 기능
- **행 추가**: 테이블 끝 또는 특정 위치에 하나 이상의 행 추가
- **스타일 복사**: 기존 행에서 셀 스타일을 복사하여 일관성 유지
- **값 초기화**: 추가 시 셀 값을 바로 설정 가능
- **rowSpan 처리**: 병합된 셀이 있는 경우 자동으로 span 확장

### 변경 파일
- `src/hwpx_mcp_server/hwpx_ops.py`: `add_table_rows` 구현 및 헬퍼 메서드
- `src/hwpx_mcp_server/tools.py`: `AddTableRowsInput/Output` 모델 및 도구 등록
- `tests/test_mcp_end_to_end.py`: 테스트 케이스 3개 추가

### API
```python
add_table_rows(
    tableIndex: int,                      # 대상 테이블의 0-based 인덱스
    count: int = 1,                       # 추가할 행 수 (최소 1)
    position: Optional[int] = None,       # 삽입 위치 (None=끝에 추가, 0=맨 앞에 삽입)
    copyStyleFrom: Optional[int] = None,  # 스타일을 복사할 행 인덱스 (None=마지막 행)
    values: Optional[Sequence[Sequence[str]]] = None,  # 셀 값 2D 배열 (행 수는 count와 일치)
    dryRun: bool = False                  # 테스트 모드
)
```