### PR TITLE
feat: fill_template 도구 추가 — 템플릿 일괄 치환 지원

### DIFF
--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -1495,6 +1495,39 @@ class HwpxOps:
         document.save(out_path)
         return {"outPath": str(out_path)}
 
+    def fill_template(
+        self,
+        source: str,
+        output: str,
+        replacements: Dict[str, str],
+        *,
+        preserve_style: bool = True,
+        split_newlines: bool = True,
+    ) -> Dict[str, Any]:
+        document, _ = self._open_document(source)
+        out_path = self._resolve_output_path(output)
+
+        replaced_count = 0
+        for needle, replacement in replacements.items():
+            if not needle:
+                continue
+            content = replacement
+            if not split_newlines:
+                content = content.replace("\r\n", " ").replace("\n", " ")
+
+            replaced_count += document.replace_text_in_runs(needle, content)
+
+        if not preserve_style:
+            logger.debug(
+                "fill_template called with preserve_style=False, but current backend always preserves run style"
+            )
+
+        document.save(out_path)
+        return {
+            "outPath": str(out_path),
+            "replacedCount": replaced_count,
+        }
+
     def make_blank(self, out: str) -> Dict[str, Any]:
         document = HwpxDocument.new()
         out_path = self._resolve_output_path(out)
@@ -1762,4 +1795,3 @@ class HwpxOps:
 
         xml_string = ET.tostring(element, encoding="unicode")
         return {"xmlString": xml_string}
-

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -418,6 +418,19 @@ class OutPathOutput(_BaseModel):
     outPath: str
 
 
+class FillTemplateInput(_BaseModel):
+    source: str
+    output: str
+    replacements: Dict[str, str]
+    preserve_style: bool = Field(True, alias="preserveStyle")
+    split_newlines: bool = Field(True, alias="splitNewlines")
+
+
+class FillTemplateOutput(_BaseModel):
+    outPath: str
+    replacedCount: int
+
+
 class MakeBlankInput(_BaseModel):
     out: str
 
@@ -736,6 +749,13 @@ def build_tool_definitions() -> List[ToolDefinition]:
             input_model=SaveAsInput,
             output_model=OutPathOutput,
             func=_simple("save_as"),
+        ),
+        ToolDefinition(
+            name="fill_template",
+            description="Copy a template and apply multiple text replacements in one call.",
+            input_model=FillTemplateInput,
+            output_model=FillTemplateOutput,
+            func=_simple("fill_template", require_path=False),
         ),
         ToolDefinition(
             name="make_blank",

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -258,6 +258,26 @@ def test_save_as_creates_new_file(ops_with_sample, tmp_path):
     result = ops.save_as(str(path), str(out))
     assert Path(result["outPath"]).exists()
 
+
+def test_fill_template_replaces_multiple_tokens_without_modifying_source(ops_with_sample):
+    ops, path = ops_with_sample
+    out = path.with_name("filled.hwpx")
+
+    result = ops.fill_template(
+        str(path),
+        str(out),
+        {"HWPX": "DOCX", "sample": "example"},
+    )
+
+    assert result["replacedCount"] >= 2
+    assert Path(result["outPath"]).exists()
+
+    source_text = ops.read_text(str(path), limit=5)["textChunk"]
+    filled_text = ops.read_text(str(out), limit=5)["textChunk"]
+    assert "HWPX" in source_text
+    assert "DOCX" in filled_text
+    assert "example DOCX" in filled_text
+
 def test_add_table_returns_valid_index(ops_with_sample):
     ops, path = ops_with_sample
     result = ops.add_table(str(path), rows=2, cols=2)

--- a/tests/test_mcp_end_to_end.py
+++ b/tests/test_mcp_end_to_end.py
@@ -129,7 +129,7 @@ async def test_list_tools_request_returns_full_set(monkeypatch, tmp_path: Path) 
     import hwpx_mcp_server.server as server_module
 
     tools = build_tool_definitions()
-    assert len(tools) == 38
+    assert len(tools) == 39
 
     created_servers: list = []
 
@@ -175,7 +175,7 @@ async def test_list_tools_request_returns_full_set(monkeypatch, tmp_path: Path) 
 
     result = response.root
     assert isinstance(result, types.ListToolsResult)
-    assert len(result.tools) == 38
+    assert len(result.tools) == 39
     assert result.nextCursor is None
 
 


### PR DESCRIPTION
### Motivation
- 양식 기반 워크플로에서 여러 번의 도구 호출로 인해 동일 문서를 반복 파싱하는 비효율을 완화하기 위해 템플릿 복사 및 다중 치환을 단일 호출로 처리할 필요가 있었습니다.
- 리포트의 우선순위(Phase 1) 제안 중 "fill_template"와 같은 고수준 배치 도구를 먼저 도입하여 사용자 경험과 처리 속도를 개선하려는 목적입니다.

### Description
- `HwpxOps.fill_template(source, output, replacements, preserve_style, split_newlines)` 메서드를 추가해 템플릿 파일을 열어 치환을 적용하고 결과를 지정한 출력 경로로 저장하도록 구현했습니다 (`src/hwpx_mcp_server/hwpx_ops.py`).
- MCP 도구 스키마에 `FillTemplateInput`/`FillTemplateOutput` 모델을 추가하고 `build_tool_definitions()`에 `fill_template` 도구를 등록해 MCP 도구로 호출할 수 있도록 했습니다 (`src/hwpx_mcp_server/tools.py`).
- 단일 호출에서 개행 처리 옵션인 `splitNewlines`를 지원하며 `preserveStyle=False` 옵션은 현재 백엔드 제약으로 스타일 보존 동작과 동등함을 로그로 명시했습니다.
- 관련 테스트를 추가/수정하여 `fill_template` 동작과 도구 목록 변화(38→39)를 반영했습니다 (`tests/test_hwpx_ops.py`, `tests/test_mcp_end_to_end.py`).

### Testing
- 새 기능 전용 단위 테스트 `tests/test_hwpx_ops.py::test_fill_template_replaces_multiple_tokens_without_modifying_source`를 추가하고 `tests/test_mcp_end_to_end.py`의 도구 개수 검증을 `39`로 갱신한 뒤 테스트를 실행했습니다.
- 실행한 명령은 `pytest -q tests/test_hwpx_ops.py::test_fill_template_replaces_multiple_tokens_without_modifying_source tests/test_mcp_end_to_end.py::test_list_tools_request_returns_full_set tests/test_tool_schemas.py`이며 초기 실패를 수정한 후 재실행에서 성공했습니다.
- 이후 전체 관련 테스트를 `pytest -q tests/test_hwpx_ops.py tests/test_mcp_end_to_end.py::test_list_tools_request_returns_full_set`로 실행했으며 모든 대상 테스트가 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b36eeb60083218c88b7f424832cd0)