### PR TITLE
feat: HWP → HWPX 자동 변환 도구(`convert_hwp_to_hwpx`) 추가

### DIFF
--- a/src/hwpx_mcp_server/hwp_converter.py
+++ b/src/hwpx_mcp_server/hwp_converter.py
@@ -1,0 +1,221 @@
+"""HWP(.hwp) -> HWPX(.hwpx) 변환 유틸리티."""
+
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from hwpx.document import HwpxDocument
+
+from .hwp_support import HwpBinaryError, extract_hwp_text
+
+
+class HwpConversionError(RuntimeError):
+    """HWP 변환 과정에서 발생하는 오류."""
+
+
+@dataclass(slots=True)
+class TablePayload:
+    """변환 대상 표 데이터."""
+
+    rows: List[List[str]]
+
+
+@dataclass(slots=True)
+class ConversionResult:
+    """HWP -> HWPX 변환 결과 요약."""
+
+    success: bool
+    output_path: str
+    paragraphs_converted: int
+    tables_converted: int
+    skipped_elements: List[str]
+    warnings: List[str]
+
+
+def _local_name(tag: str) -> str:
+    if "}" in tag:
+        return tag.rsplit("}", 1)[1]
+    return tag
+
+
+def _iter_by_names(root: ET.Element, names: Sequence[str]) -> Iterable[ET.Element]:
+    wanted = {name.lower() for name in names}
+    for element in root.iter():
+        if _local_name(element.tag).lower() in wanted:
+            yield element
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _collect_paragraph_text(paragraph_element: ET.Element) -> str:
+    text_chunks: List[str] = []
+    for element in paragraph_element.iter():
+        local = _local_name(element.tag).lower()
+        if local in {"text", "t", "char"} and element.text:
+            normalized = _normalize_text(element.text)
+            if normalized:
+                text_chunks.append(normalized)
+    if not text_chunks:
+        for part in paragraph_element.itertext():
+            normalized = _normalize_text(part)
+            if normalized:
+                text_chunks.append(normalized)
+    return " ".join(text_chunks).strip()
+
+
+def _parse_table_rows(table_element: ET.Element) -> TablePayload | None:
+    row_elements = list(_iter_by_names(table_element, ["TableRow", "tr", "row"]))
+    rows: List[List[str]] = []
+
+    if row_elements:
+        for row_element in row_elements:
+            row_cells: List[str] = []
+            cell_elements = list(_iter_by_names(row_element, ["TableCell", "tc", "cell", "td"]))
+            for cell_element in cell_elements:
+                text = _collect_paragraph_text(cell_element)
+                row_cells.append(text)
+            if row_cells:
+                rows.append(row_cells)
+    else:
+        cells = list(_iter_by_names(table_element, ["TableCell", "tc", "cell", "td"]))
+        if cells:
+            rows.append([_collect_paragraph_text(cell) for cell in cells])
+
+    if not rows:
+        return None
+
+    max_cols = max(len(row) for row in rows)
+    for row in rows:
+        if len(row) < max_cols:
+            row.extend([""] * (max_cols - len(row)))
+    return TablePayload(rows=rows)
+
+
+def _parse_hwp5proc_xml(xml_text: str) -> tuple[List[str], List[TablePayload], List[str]]:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise HwpConversionError(f"hwp5proc XML 파싱 실패: {exc}") from exc
+
+    paragraphs: List[str] = []
+    tables: List[TablePayload] = []
+    warnings: List[str] = []
+    parent_map = {child: parent for parent in root.iter() for child in parent}
+
+    def _inside_table(node: ET.Element) -> bool:
+        current = parent_map.get(node)
+        while current is not None:
+            if _local_name(current.tag).lower() in {"tablecontrol", "tbl", "table"}:
+                return True
+            current = parent_map.get(current)
+        return False
+
+    for paragraph_element in _iter_by_names(root, ["Paragraph", "p", "para"]):
+        if _inside_table(paragraph_element):
+            continue
+        text = _collect_paragraph_text(paragraph_element)
+        if text:
+            paragraphs.append(text)
+
+    for table_element in _iter_by_names(root, ["TableControl", "tbl", "table"]):
+        parsed = _parse_table_rows(table_element)
+        if parsed is not None:
+            tables.append(parsed)
+
+    if not paragraphs:
+        warnings.append("문단 노드를 직접 매핑하지 못해 보조 텍스트 추출로 대체될 수 있습니다.")
+
+    return paragraphs, tables, warnings
+
+
+def _run_hwp5proc_xml(hwp_path: Path) -> str:
+    try:
+        completed = subprocess.run(
+            ["hwp5proc", "xml", "--format", "nested", str(hwp_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError as exc:
+        raise HwpConversionError("hwp5proc 명령을 찾을 수 없습니다. pyhwp 설치 여부를 확인하세요.") from exc
+
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or "unknown error"
+        raise HwpConversionError(f"hwp5proc 실행 실패: {stderr}")
+
+    xml_text = completed.stdout.strip()
+    if not xml_text:
+        raise HwpConversionError("hwp5proc XML 출력이 비어 있습니다")
+    return xml_text
+
+
+def convert_hwp_to_hwpx(hwp_path: str, output_path: str) -> ConversionResult:
+    source = Path(hwp_path).expanduser().resolve()
+    target = Path(output_path).expanduser().resolve()
+
+    if source.suffix.lower() != ".hwp":
+        raise HwpConversionError("source는 .hwp 파일이어야 합니다")
+    if not source.exists():
+        raise HwpConversionError(f"입력 파일이 존재하지 않습니다: {source}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    xml_text = _run_hwp5proc_xml(source)
+    paragraphs, tables, warnings = _parse_hwp5proc_xml(xml_text)
+
+    skipped_elements: List[str] = []
+    unsupported_pairs = [
+        ("OLE 개체", ["OLE", "OleObject"]),
+        ("각주/미주", ["FootNote", "EndNote"]),
+        ("변경 추적", ["TrackChange", "Revision"]),
+        ("양식 컨트롤", ["FormObject", "Field"]),
+    ]
+    for label, tags in unsupported_pairs:
+        if any(f"<{tag}" in xml_text for tag in tags):
+            skipped_elements.append(label)
+
+    if not paragraphs:
+        try:
+            fallback = extract_hwp_text(source)
+        except HwpBinaryError:
+            fallback = None
+        if fallback and fallback.paragraphs:
+            paragraphs = list(fallback.paragraphs)
+            warnings.append(f"pyhwp XML 직접 매핑 실패로 {fallback.source} 텍스트를 사용했습니다.")
+
+    document = HwpxDocument.new()
+    for paragraph_text in paragraphs:
+        document.add_paragraph(paragraph_text)
+
+    for table_payload in tables:
+        row_count = len(table_payload.rows)
+        col_count = len(table_payload.rows[0]) if table_payload.rows else 0
+        if row_count <= 0 or col_count <= 0:
+            continue
+        table = document.add_table(rows=row_count, cols=col_count)
+        for row_index, row in enumerate(table_payload.rows):
+            for col_index, text in enumerate(row):
+                table.rows[row_index].cells[col_index].text = text
+
+    document.save(target)
+
+    if skipped_elements:
+        warnings.append(
+            "변환 제외 요소: " + ", ".join(skipped_elements)
+        )
+
+    return ConversionResult(
+        success=True,
+        output_path=str(target),
+        paragraphs_converted=len(paragraphs),
+        tables_converted=len(tables),
+        skipped_elements=skipped_elements,
+        warnings=warnings,
+    )

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -418,6 +418,20 @@ class OutPathOutput(_BaseModel):
     outPath: str
 
 
+class ConvertHwpToHwpxInput(_BaseModel):
+    source: str
+    output: Optional[str] = None
+
+
+class ConvertHwpToHwpxOutput(_BaseModel):
+    success: bool
+    outputPath: str
+    paragraphsConverted: int
+    tablesConverted: int
+    skippedElements: List[str]
+    warnings: List[str]
+
+
 class FillTemplateInput(_BaseModel):
     source: str
     output: str
@@ -763,6 +777,13 @@ def build_tool_definitions() -> List[ToolDefinition]:
             input_model=MakeBlankInput,
             output_model=OutPathOutput,
             func=_simple("make_blank"),
+        ),
+        ToolDefinition(
+            name="convert_hwp_to_hwpx",
+            description="Convert a .hwp binary document into .hwpx.",
+            input_model=ConvertHwpToHwpxInput,
+            output_model=ConvertHwpToHwpxOutput,
+            func=_simple("convert_hwp_to_hwpx", require_path=False),
         ),
         ToolDefinition(
             name="list_master_pages_histories_versions",

--- a/tests/test_hwp_converter.py
+++ b/tests/test_hwp_converter.py
@@ -1,0 +1,82 @@
+import subprocess
+
+from hwpx.document import HwpxDocument
+
+from hwpx_mcp_server.hwp_converter import convert_hwp_to_hwpx
+from hwpx_mcp_server.hwpx_ops import HwpxOps
+
+
+def _table_count(document: HwpxDocument) -> int:
+    tables = []
+    for paragraph in document.paragraphs:
+        tables.extend(paragraph.tables)
+    return len(tables)
+
+
+def test_convert_hwp_to_hwpx_maps_text_and_table(monkeypatch, tmp_path):
+    source = tmp_path / "sample.hwp"
+    source.write_bytes(b"dummy")
+    output = tmp_path / "sample.hwpx"
+
+    xml_payload = """
+    <HwpDoc>
+      <Paragraph><Text>첫 문단</Text></Paragraph>
+      <Paragraph><Text>둘째 문단</Text></Paragraph>
+      <TableControl>
+        <TableRow>
+          <TableCell><Paragraph><Text>A1</Text></Paragraph></TableCell>
+          <TableCell><Paragraph><Text>B1</Text></Paragraph></TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell><Paragraph><Text>A2</Text></Paragraph></TableCell>
+          <TableCell><Paragraph><Text>B2</Text></Paragraph></TableCell>
+        </TableRow>
+      </TableControl>
+      <OLE />
+    </HwpDoc>
+    """.strip()
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(args=["hwp5proc"], returncode=0, stdout=xml_payload, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = convert_hwp_to_hwpx(str(source), str(output))
+
+    assert result.success is True
+    assert result.paragraphs_converted == 2
+    assert result.tables_converted == 1
+    assert "OLE 개체" in result.skipped_elements
+
+    converted = HwpxDocument.open(output)
+    assert len(list(converted.paragraphs)) >= 2
+    assert _table_count(converted) == 1
+
+    ops = HwpxOps(base_directory=tmp_path)
+    validation = ops.validate_structure(output.name)
+    assert validation["ok"] is True
+
+
+def test_convert_hwp_to_hwpx_warns_for_unsupported(monkeypatch, tmp_path):
+    source = tmp_path / "warn.hwp"
+    source.write_bytes(b"dummy")
+    output = tmp_path / "warn.hwpx"
+
+    xml_payload = """
+    <HwpDoc>
+      <Paragraph><Text>본문</Text></Paragraph>
+      <FootNote><Text>주석</Text></FootNote>
+      <Revision><Text>변경</Text></Revision>
+    </HwpDoc>
+    """.strip()
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(args=["hwp5proc"], returncode=0, stdout=xml_payload, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = convert_hwp_to_hwpx(str(source), str(output))
+
+    assert "각주/미주" in result.skipped_elements
+    assert "변경 추적" in result.skipped_elements
+    assert any("변환 제외 요소" in item for item in result.warnings)

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -713,4 +713,4 @@ def test_hwp_edit_tools_raise_clear_error(tmp_path):
     with pytest.raises(Exception) as exc_info:
         ops.replace_text_in_runs(hwp_path.name, "A", "B")
 
-    assert "읽기 전용" in str(exc_info.value)
+    assert "convert_hwp_to_hwpx" in str(exc_info.value)

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -65,3 +65,8 @@ def test_open_info_meta_allows_additional_properties():
     }
 
     jsonschema.validate(sample, schema)
+
+
+def test_convert_hwp_to_hwpx_tool_is_exposed():
+    names = {definition.name for definition in build_tool_definitions()}
+    assert "convert_hwp_to_hwpx" in names


### PR DESCRIPTION
### Motivation

- 기존에는 `.hwp` 파일이 읽기 전용으로만 지원되어 편집하려면 사용자가 외부에서 HWPX로 변환해야 했으므로 MCP 서버 내에서 자동 변환을 제공해 편의성을 높이고 편집 파이프라인에 바로 연결하려는 목적입니다. 
- 기술적으로는 `pyhwp`의 `hwp5proc xml` 출력 결과를 파싱해 `python-hwpx`의 문서 생성 API에 매핑하는 현실적 범위(P0/P1 중심)를 우선 지원하도록 설계했습니다.

### Description

- 새로운 변환 모듈 `src/hwpx_mcp_server/hwp_converter.py`를 추가했고 `convert_hwp_to_hwpx(hwp_path: str, output_path: str) -> ConversionResult` 함수를 구현했습니다. 
- 서버 연계로 `HwpxOps.convert_hwp_to_hwpx(source, output=None)`를 추가하고 `.hwp` 편집 시 출력되는 안내 문구를 `convert_hwp_to_hwpx` 사용 권장으로 변경했습니다. 
- MCP 도구 표면에 `convert_hwp_to_hwpx`를 노출하도록 `src/hwpx_mcp_server/tools.py`에 입력/출력 모델(`source`, `output?` 및 변환 요약 필드)과 `ToolDefinition` 등록을 추가했습니다. 
- 변환은 문단 텍스트와 표(행/열/셀 텍스트)를 우선 이전하며 OLE/각주/변경추적/양식 컨트롤 등 고급 요소는 감지해 `skippedElements`와 `warnings`로 보고하도록 구현했고, XML 직접 매핑 실패 시 `PrvText/BodyText` 추출으로 폴백합니다. 
- 문서화로 `README.md`에 도구 사용법·지원 범위·제한사항을 추가했고 테스트를 위해 `tests/test_hwp_converter.py`를 새로 만들었으며 기존 테스트(`tests/test_hwpx_ops.py`, `tests/test_tool_schemas.py`)를 일부 갱신했습니다.

### Testing

- 실행한 자동화 테스트: `pytest -q tests/test_hwp_converter.py tests/test_hwpx_ops.py::test_hwp_edit_tools_raise_clear_error tests/test_tool_schemas.py::test_convert_hwp_to_hwpx_tool_is_exposed`이 성공했습니다. 
- 추가로 `pytest -q tests/test_hwpx_ops.py::test_hwp_open_info_returns_read_only_metadata tests/test_hwpx_ops.py::test_hwp_read_text_and_find_use_read_only_pipeline tests/test_tool_schemas.py`도 성공하여 관련 엔드포인트와 스키마 변경이 통과했음을 확인했습니다. 
- 단위/통합 테스트에서 변환 로직은 모의 `hwp5proc xml` 출력을 사용해 문단/표 매핑과 변환 제외 요소 경고를 검증했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3dcd2b44832194f1f8ed8d9df473)