### PR TITLE
핸들 기반 MCP Resources 및 URI 계약 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,3 +409,29 @@ python -m pytest
   }
 }
 ```
+
+## 📚 Resources 사용 예시 및 URI 계약
+
+MCP Resources를 통해 **등록된 handle 기반 읽기 전용 조회**를 사용할 수 있습니다. 서버는 도구 호출 과정에서 실제 문서 경로를 해석할 때 handle을 자동 등록하며, `resources/list`에서는 현재 등록된 handle만 노출합니다.
+
+### URI 스킴
+
+- `hwpx://documents/{handle}/metadata`: 문서 메타데이터/섹션·문단·헤더 개수
+- `hwpx://documents/{handle}/paragraphs`: 문서 전체 문단 텍스트
+- `hwpx://documents/{handle}/tables`: 표 인덱스/행/열 요약
+
+`{handle}`은 `h_<16자리해시>` 형태의 불투명 식별자이며, 등록되지 않은 handle은 표준화된 `HANDLE_NOT_FOUND` 에러로 반환됩니다.
+
+### 호출 흐름 예시
+
+1. 먼저 도구(예: `open_info`, `read_text`)를 호출해 문서를 열면 해당 문서 handle이 등록됩니다.
+2. `resources/list`를 호출하면 해당 handle의 `metadata/paragraphs/tables` URI가 나타납니다.
+3. `resources/read`로 원하는 URI를 읽어 JSON(`application/json`) 본문을 받습니다.
+
+예시 URI:
+
+```text
+hwpx://documents/h_0123456789abcdef/metadata
+hwpx://documents/h_0123456789abcdef/paragraphs
+hwpx://documents/h_0123456789abcdef/tables
+```

--- a/src/hwpx_mcp_server/core/locator.py
+++ b/src/hwpx_mcp_server/core/locator.py
@@ -42,6 +42,15 @@ class HandleLocator(_LocatorModel):
     backend: Optional[str] = None
 
 
+class RegisteredHandle(_LocatorModel):
+    """서버가 관리하는 등록 핸들의 읽기 전용 직렬화 모델."""
+
+    type: Literal["handle"] = Field("handle", alias="type")
+    handle_id: str = Field(alias="handleId")
+    path: str
+    backend: Optional[str] = None
+
+
 DocumentLocator = Annotated[
     PathLocator | UriLocator | HandleLocator,
     Field(discriminator="type"),

--- a/src/hwpx_mcp_server/core/resources.py
+++ b/src/hwpx_mcp_server/core/resources.py
@@ -1,0 +1,41 @@
+"""MCP Resource 직렬화 모델."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ResourceModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+
+class ParagraphResourceEntry(ResourceModel):
+    paragraph_index: int = Field(alias="paragraphIndex")
+    text: str
+
+
+class TableResourceEntry(ResourceModel):
+    table_index: int = Field(alias="tableIndex")
+    row_count: int = Field(alias="rowCount")
+    column_count: int = Field(alias="columnCount")
+
+
+class DocumentMetadataResource(ResourceModel):
+    handle_id: str = Field(alias="handleId")
+    locator: Dict[str, Any]
+    meta: Dict[str, Any]
+    section_count: int = Field(alias="sectionCount")
+    paragraph_count: int = Field(alias="paragraphCount")
+    header_count: int = Field(alias="headerCount")
+
+
+class DocumentParagraphsResource(ResourceModel):
+    handle_id: str = Field(alias="handleId")
+    paragraphs: List[ParagraphResourceEntry]
+
+
+class DocumentTablesResource(ResourceModel):
+    handle_id: str = Field(alias="handleId")
+    tables: List[TableResourceEntry]


### PR DESCRIPTION
### Motivation

- 도구 호출 과정에서 해석한 문서 핸들에 대해 MCP `resources` API로 읽기 전용 메타데이터·문단·표를 제공하기 위해 리소스 핸들러와 URI 계약이 필요했습니다.
- 등록된 핸들만 목록에 노출하고, 미등록 핸들 조회는 표준화된 에러로 반환하도록 하여 안전한 공개 인터페이스를 설계했습니다.

### Description

- `server.py`에 MCP 리소스 핸들러를 추가해 `ListResources`, `ListResourceTemplates`, `ReadResource` 요청을 처리하고 `hwpx://documents/{handle}/(metadata|paragraphs|tables)` URI를 파싱하도록 구현했습니다.
- `core/locator.py`에 서버 내부에서 사용하는 읽기 전용 핸들 직렬화 모델인 `RegisteredHandle`을 추가했습니다.
- `hwpx_ops.py`에 핸들 레지스트리(`_registered_handles`)를 도입하고, 경로 해석 시 핸들을 자동 등록하도록 연결했으며 핸들 기반 조회 API인 `list_registered_handles`, `get_registered_handle`, `get_metadata_by_handle`, `get_paragraphs_by_handle`, `get_tables_by_handle`를 구현했습니다.
- `core/resources.py`에 리소스 응답용 읽기 전용 Pydantic 모델(`DocumentMetadataResource`, `DocumentParagraphsResource`, `DocumentTablesResource` 등)을 추가해 JSON 직렬화를 정형화했습니다.
- `README.md`에 Resources 사용 예시와 URI 스킴/에러 계약(예: `HANDLE_NOT_FOUND`, `code=-32040`) 문서를 한글로 추가했습니다.
- `tests/test_mcp_end_to_end.py`에 리소스 목록·읽기 및 미등록 핸들 오류 동작을 검증하는 테스트를 추가/수정했습니다.

### Testing

- `python -m pytest tests/test_mcp_end_to_end.py tests/test_locator_models.py`를 실행했으며 전체 테스트가 통과하여 `20 passed`를 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d0e765f48321b24a5a9bbb72dbff)