### PR TITLE
feat: MCP prompts/list,get 핸들러 및 버전드 프롬프트 템플릿 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,66 @@ uvx hwpx-mcp-server --transport streamable-http --host 0.0.0.0 --port 8080
 - **`hwpx.search`**: 정규식 또는 키워드 기반으로 문서 전반을 검색하여 노출 가능한 문맥만 포함한 일치 결과를 제공합니다.
 - **`hwpx.get_context`**: 특정 문단 주변의 제한된 창(window)만 추출하여 프라이버시를 유지한 채 리뷰에 활용할 수 있습니다.
 
+
+## 🧠 Prompt 템플릿 (prompts/list, prompts/get)
+
+서버는 바로 호출 가능한 버전드 프롬프트 ID를 제공합니다. 버전 호환성 관리를 위해 `prompt_id@vN` 네이밍 규칙을 사용합니다.
+
+- `summary@v1`: 문서 전체 텍스트 요약
+- `table_to_csv@v1`: 표 추출 후 CSV 변환
+- `document_lint@v1`: 텍스트 규칙 린트
+
+각 프롬프트는 설명에 **도구 이름/인자명 ↔ 템플릿 변수 매핑**, 인자 스키마, 예시 입력/출력을 포함합니다.
+
+### 예시 1) prompts/get으로 요약 프롬프트 요청
+
+```json
+{
+  "method": "prompts/get",
+  "params": {
+    "name": "summary@v1",
+    "arguments": {
+      "path": "sample.hwpx",
+      "summaryStyle": "임원 보고",
+      "maxSentences": "4"
+    }
+  }
+}
+```
+
+### 예시 2) prompts/get으로 표 CSV 프롬프트 요청
+
+```json
+{
+  "method": "prompts/get",
+  "params": {
+    "name": "table_to_csv@v1",
+    "arguments": {
+      "path": "sample.hwpx",
+      "tableIndex": "0",
+      "delimiter": ",",
+      "headerPolicy": "첫 행 헤더 유지"
+    }
+  }
+}
+```
+
+### 예시 3) prompts/get으로 문서 린트 프롬프트 요청
+
+```json
+{
+  "method": "prompts/get",
+  "params": {
+    "name": "document_lint@v1",
+    "arguments": {
+      "path": "sample.hwpx",
+      "maxLineLen": "100",
+      "forbidPatterns": "\"TODO\", \"TBD\""
+    }
+  }
+}
+```
+
 ## 🛠️ 제공 도구
 
 다양한 문서 편집 및 관리 도구를 제공합니다. 각 도구의 상세한 입출력 형식은 `ListTools` 응답에 포함된 JSON 스키마를 통해 확인할 수 있습니다.

--- a/src/hwpx_mcp_server/prompts.py
+++ b/src/hwpx_mcp_server/prompts.py
@@ -1,0 +1,266 @@
+"""MCP prompts/list, prompts/get에 노출할 프롬프트 정의."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from string import Formatter
+from typing import Mapping, Sequence
+
+import mcp.types as types
+
+
+@dataclass(frozen=True)
+class PromptArgumentSpec:
+    """프롬프트 인자 메타데이터."""
+
+    name: str
+    description: str
+    required: bool = True
+    schema: Mapping[str, object] | None = None
+
+    def to_prompt_argument(self) -> types.PromptArgument:
+        return types.PromptArgument(
+            name=self.name,
+            description=self.description,
+            required=self.required,
+        )
+
+
+@dataclass(frozen=True)
+class ToolBinding:
+    """템플릿 변수와 도구 인자의 매핑 정의."""
+
+    tool_name: str
+    arguments_template: str
+
+
+@dataclass(frozen=True)
+class PromptTemplate:
+    """버전 가능한 프롬프트 템플릿 정의."""
+
+    prompt_id: str
+    version: str
+    title: str
+    description: str
+    template: str
+    arguments: Sequence[PromptArgumentSpec]
+    tool_bindings: Sequence[ToolBinding]
+    example_input: Mapping[str, str]
+    example_output: str
+
+    @property
+    def name(self) -> str:
+        # 버전 호환성 관리를 위해 ID에 명시적으로 버전을 포함한다.
+        return f"{self.prompt_id}@{self.version}"
+
+    def to_prompt(self) -> types.Prompt:
+        return types.Prompt(
+            name=self.name,
+            title=self.title,
+            description=self._description_block(),
+            arguments=[item.to_prompt_argument() for item in self.arguments],
+        )
+
+    def render(self, values: Mapping[str, str] | None) -> types.GetPromptResult:
+        normalized = self._normalize_values(values)
+        text = self.template.format(**normalized)
+        return types.GetPromptResult(
+            description=self._description_block(),
+            messages=[
+                types.PromptMessage(
+                    role="user",
+                    content=types.TextContent(type="text", text=text),
+                )
+            ],
+        )
+
+    def _description_block(self) -> str:
+        schema_lines = [
+            f"- `{arg.name}`: {arg.schema if arg.schema is not None else {'type': 'string'}}"
+            for arg in self.arguments
+        ]
+        binding_lines = [
+            f"- `{binding.tool_name}` ← {binding.arguments_template}"
+            for binding in self.tool_bindings
+        ]
+        return "\n".join(
+            [
+                self.description,
+                "",
+                f"prompt_id: `{self.prompt_id}`",
+                f"version: `{self.version}`",
+                "",
+                "인자 스키마:",
+                *schema_lines,
+                "",
+                "도구 매핑(도구 이름/인자명 ↔ 템플릿 변수):",
+                *binding_lines,
+                "",
+                f"예시 입력: {dict(self.example_input)}",
+                f"예시 출력: {self.example_output}",
+            ]
+        )
+
+    def _normalize_values(self, values: Mapping[str, str] | None) -> dict[str, str]:
+        incoming = dict(values or {})
+        normalized: dict[str, str] = {}
+        for argument in self.arguments:
+            raw = incoming.get(argument.name)
+            if raw is None:
+                if argument.required:
+                    raise ValueError(f"프롬프트 인자 '{argument.name}'가 필요합니다.")
+                normalized[argument.name] = ""
+                continue
+            normalized[argument.name] = str(raw)
+
+        for _, field_name, _, _ in Formatter().parse(self.template):
+            if not field_name:
+                continue
+            normalized.setdefault(field_name, "")
+
+        return normalized
+
+
+PROMPT_TEMPLATES: tuple[PromptTemplate, ...] = (
+    PromptTemplate(
+        prompt_id="summary",
+        version="v1",
+        title="문서 요약",
+        description="HWPX 문서 전체 텍스트를 읽어 지정 길이로 요약합니다.",
+        template=(
+            "아래 순서로 HWPX 문서를 요약해 주세요.\n"
+            "1) 도구 `open_info`를 호출해 문서 기본 정보(문단 수, 섹션 수)를 확인\n"
+            "   - arguments: {{\"path\": \"{path}\"}}\n"
+            "2) 도구 `text_extract_report`를 호출해 전체 텍스트를 읽기\n"
+            "   - arguments: {{\"path\": \"{path}\", \"mode\": \"plain\"}}\n"
+            "3) 추출 텍스트를 {summaryStyle} 스타일로 {maxSentences}문장 이내 한국어 요약으로 정리\n"
+            "4) 마지막에 핵심 키워드 3개를 bullet로 제시\n"
+        ),
+        arguments=(
+            PromptArgumentSpec(
+                name="path",
+                description="요약할 HWPX 파일 경로",
+                schema={"type": "string", "minLength": 1},
+            ),
+            PromptArgumentSpec(
+                name="summaryStyle",
+                description="요약 톤(예: 임원 보고, 일반 설명)",
+                schema={"type": "string", "default": "일반 설명"},
+            ),
+            PromptArgumentSpec(
+                name="maxSentences",
+                description="최대 요약 문장 수",
+                schema={"type": "string", "default": "5"},
+            ),
+        ),
+        tool_bindings=(
+            ToolBinding("open_info", '{"path": "{path}"}'),
+            ToolBinding("text_extract_report", '{"path": "{path}", "mode": "plain"}'),
+        ),
+        example_input={"path": "sample.hwpx", "summaryStyle": "임원 보고", "maxSentences": "4"},
+        example_output="문서의 목적/핵심 내용 4문장 요약 + 키워드 3개",
+    ),
+    PromptTemplate(
+        prompt_id="table_to_csv",
+        version="v1",
+        title="표 추출 → CSV",
+        description="특정 표를 추출해 CSV 텍스트로 변환합니다.",
+        template=(
+            "다음 절차로 표를 CSV로 변환해 주세요.\n"
+            "1) 도구 `get_table_cell_map` 호출\n"
+            "   - arguments: {{\"path\": \"{path}\", \"tableIndex\": {tableIndex}}}\n"
+            "2) 반환된 grid를 순회하면서 anchor 기준으로 값을 정규화\n"
+            "3) {delimiter} 구분자를 사용해 CSV 본문 생성\n"
+            "4) 첫 줄은 헤더로 간주: {headerPolicy}\n"
+            "5) 최종 출력은 코드블록 없이 순수 CSV 텍스트만 반환\n"
+        ),
+        arguments=(
+            PromptArgumentSpec(
+                name="path",
+                description="표를 읽을 HWPX 파일 경로",
+                schema={"type": "string", "minLength": 1},
+            ),
+            PromptArgumentSpec(
+                name="tableIndex",
+                description="추출할 표의 0-기반 인덱스",
+                schema={"type": "string", "pattern": "^[0-9]+$"},
+            ),
+            PromptArgumentSpec(
+                name="delimiter",
+                description="CSV 구분자",
+                schema={"type": "string", "default": ","},
+            ),
+            PromptArgumentSpec(
+                name="headerPolicy",
+                description="헤더 처리 규칙(예: 첫 행 헤더 유지)",
+                schema={"type": "string", "default": "첫 행 헤더 유지"},
+            ),
+        ),
+        tool_bindings=(
+            ToolBinding("get_table_cell_map", '{"path": "{path}", "tableIndex": {tableIndex}}'),
+        ),
+        example_input={
+            "path": "sample.hwpx",
+            "tableIndex": "0",
+            "delimiter": ",",
+            "headerPolicy": "첫 행 헤더 유지",
+        },
+        example_output="항목,수량,비고\n사과,10,국내\n배,5,수입",
+    ),
+    PromptTemplate(
+        prompt_id="document_lint",
+        version="v1",
+        title="문서 린트",
+        description="문서 텍스트 규칙 위반 항목을 점검합니다.",
+        template=(
+            "아래 린트 절차를 수행해 주세요.\n"
+            "1) 도구 `lint_text_conventions` 호출\n"
+            "   - arguments: {{\"path\": \"{path}\", \"rules\": {{\"maxLineLen\": {maxLineLen}, \"forbidPatterns\": [{forbidPatterns}]}}}}\n"
+            "2) warnings를 심각도(높음/중간/낮음)로 재분류\n"
+            "3) 각 항목을 `문단 번호 | 문제 | 개선 제안` 형식 표로 출력\n"
+            "4) 마지막에 수정 우선순위 Top3를 제시\n"
+        ),
+        arguments=(
+            PromptArgumentSpec(
+                name="path",
+                description="린트할 HWPX 파일 경로",
+                schema={"type": "string", "minLength": 1},
+            ),
+            PromptArgumentSpec(
+                name="maxLineLen",
+                description="권장 최대 줄 길이",
+                schema={"type": "string", "default": "120", "pattern": "^[0-9]+$"},
+            ),
+            PromptArgumentSpec(
+                name="forbidPatterns",
+                description='금지 패턴 목록(예: "TODO", "임시")를 따옴표 포함 콤마로 전달',
+                schema={"type": "string", "default": '"TODO", "임시"'},
+            ),
+        ),
+        tool_bindings=(
+            ToolBinding(
+                "lint_text_conventions",
+                '{"path": "{path}", "rules": {"maxLineLen": {maxLineLen}, "forbidPatterns": [{forbidPatterns}]}}',
+            ),
+        ),
+        example_input={
+            "path": "sample.hwpx",
+            "maxLineLen": "100",
+            "forbidPatterns": '"TODO", "TBD"',
+        },
+        example_output="문단 번호 | 문제 | 개선 제안\n12 | TODO 잔존 | 실제 작업 상태로 교체",
+    ),
+)
+
+PROMPT_BY_NAME: dict[str, PromptTemplate] = {prompt.name: prompt for prompt in PROMPT_TEMPLATES}
+
+
+def list_prompts() -> list[types.Prompt]:
+    return [prompt.to_prompt() for prompt in PROMPT_TEMPLATES]
+
+
+def get_prompt(name: str, arguments: Mapping[str, str] | None) -> types.GetPromptResult:
+    prompt = PROMPT_BY_NAME.get(name)
+    if prompt is None:
+        raise KeyError(name)
+    return prompt.render(arguments)


### PR DESCRIPTION
### Motivation

- 클라이언트에서 즉시 호출 가능한 프롬프트 템플릿을 서버가 제공하여 문서 요약, 표→CSV 변환, 문서 린트 등 작업을 자동화하려는 목적입니다.
- 향후 템플릿 변경에 따른 호환성 관리를 위해 명시적 버전(네이밍 규칙)을 도입할 필요가 있었습니다.

### Description

- `src/hwpx_mcp_server/prompts.py`를 추가하여 `summary@v1`, `table_to_csv@v1`, `document_lint@v1`의 버전드 프롬프트 템플릿과 인자 스키마, 도구↔템플릿 변수 매핑, 예시 입력/출력을 선언했습니다.
- `src/hwpx_mcp_server/server.py`에 `prompts/list` 핸들러(`ListPromptsRequest`)와 `prompts/get` 핸들러(`GetPromptRequest`)를 등록해 프롬프트 목록 조회 및 렌더링 응답을 제공하도록 했습니다.
- 템플릿 변수와 도구 이름/인자명 매핑을 명시적으로 포함하고, 템플릿 렌더링 시 누락 인자 또는 잘못된 프롬프트 ID에 대해 표준 MCP 오류 코드(`-32602`)로 응답하도록 처리했습니다.
- `README.md`에 프롬프트 ID 목록, 버전 네이밍 규칙(`prompt_id@vN`) 및 `prompts/get` 호출 예시(요약, 표→CSV, 린트)를 추가했습니다.
- 클라이언트 호환성/검증을 위한 엔드투엔드 스타일 테스트를 `tests/test_mcp_end_to_end.py`에 추가하여 목록 조회, 정상 렌더링, 잘못된 ID 에러 경로를 검증했습니다.

### Testing

- `pytest -q tests/test_mcp_end_to_end.py -k "prompt_handlers_list_and_get or prompt_handler_returns_standard_error_for_unknown_prompt or resource_handlers_list_and_read"`를 실행해 관련 프롬프트 및 리소스 핸들러 테스트가 모두 통과했습니다 (성공).
- `pytest -q tests/test_tool_schemas.py`를 실행해 도구 스키마 관련 테스트도 통과했습니다 (성공).
- 추가로 프롬프트 목록 조회와 `prompts/get` 렌더링의 정상/오류 경로를 확인하는 테스트들이 성공적으로 통과했습니다 (성공).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d25304b48321913b64889fed0cd1)