### PR TITLE
공통 에러 모델 추가 및 HwpxOperationError/MCP 에러 응답 표준화

### DIFF
--- a/src/hwpx_mcp_server/errors.py
+++ b/src/hwpx_mcp_server/errors.py
@@ -1,0 +1,49 @@
+"""공통 에러 모델과 MCP 에러 변환 유틸리티."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CommonErrorModel(BaseModel):
+    """클라이언트가 일관되게 처리할 수 있는 공통 에러 페이로드."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    code: str
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    hint: Optional[str] = None
+
+
+ERROR_CODE_TO_MCP_CODE: dict[str, int] = {
+    "DOCUMENT_NOT_FOUND": -32044,
+    "PERMISSION_DENIED": -32043,
+    "TABLE_INDEX_OUT_OF_RANGE": -32042,
+    "PARAGRAPH_INDEX_OUT_OF_RANGE": -32042,
+    "PIPELINE_ERROR": -32041,
+}
+
+
+DEFAULT_MCP_ERROR_CODE = -32000
+
+
+def mcp_code_for_error(error_code: str) -> int:
+    return ERROR_CODE_TO_MCP_CODE.get(error_code, DEFAULT_MCP_ERROR_CODE)
+
+
+def build_error_payload(
+    *,
+    code: str,
+    message: str,
+    details: Optional[Dict[str, Any]] = None,
+    hint: Optional[str] = None,
+) -> Dict[str, Any]:
+    return CommonErrorModel(
+        code=code,
+        message=message,
+        details=details,
+        hint=hint,
+    ).model_dump(exclude_none=True)

--- a/tests/test_hwpx_ops.py
+++ b/tests/test_hwpx_ops.py
@@ -164,6 +164,22 @@ def test_read_text_consumes_only_requested_slice(monkeypatch, tmp_path):
         assert paragraph.text_calls == expected_calls
 
 
+
+
+def test_resolve_path_permission_error_maps_code(tmp_path, monkeypatch):
+    ops = HwpxOps(base_directory=tmp_path)
+
+    def deny(path: str, *, must_exist: bool = True):
+        raise PermissionError(path)
+
+    monkeypatch.setattr(ops.storage, "resolve_path", deny)
+
+    with pytest.raises(ops_module.HwpxOperationError) as exc_info:
+        ops.open_info("secret.hwpx")
+
+    assert exc_info.value.code == "PERMISSION_DENIED"
+    assert exc_info.value.details == {"path": "secret.hwpx"}
+
 def test_find_returns_matches(ops_with_sample):
     ops, path = ops_with_sample
     matches = ops.find(str(path), "HWPX")


### PR DESCRIPTION
### Motivation
- 도구와 하드닝 파이프라인에서 반환하는 오류 형식을 통합해 클라이언트가 일관되게 처리할 수 있도록 하기 위함입니다.
- 파일 없음/권한/인덱스/파이프라인 오류 등 대표 실패 케이스에 명시적 코드와 세부정보를 포함하도록 하여 자동화된 오류 처리와 디버깅을 용이하게 합니다.

### Description
- `src/hwpx_mcp_server/errors.py` 신설로 공통 에러 모델(`code`, `message`, `details`, `hint`)과 에러 코드→MCP 코드 매핑 유틸리티(`mcp_code_for_error`, `build_error_payload`)를 추가했습니다.
- `HwpxOperationError`를 확장해 `code`, `details`, `hint`를 보존하고 `to_payload()`로 직렬화 가능한 표준 페이로드를 반환하도록 변경했으며, `HwpxOps`에 코드 기반 예외 생성 헬퍼인 `_new_error`를 도입했습니다.
- `hwpx_ops.py` 내부에서 `FileNotFoundError`, `PermissionError`, `IndexError`, `PipelineError` 등 기존에 문자열 기반으로 발생하던 예외들을 명시 코드(예: `DOCUMENT_NOT_FOUND`, `PERMISSION_DENIED`, `TABLE_INDEX_OUT_OF_RANGE`, `PIPELINE_ERROR` 등)로 매핑하고 `details`에 경로/인덱스/파이프라인 코드 정보를 채우도록 수정했습니다.
- `server.py`의 리소스 읽기 경로 및 `_call_tool`에서 `HwpxOperationError`를 MCP 표준 `ErrorData`로 변환하도록 변경해, `code`→MCP 에러 코드 매핑 및 `data`에 공통 에러 페이로드를 포함하도록 통일했습니다; 일반 예외는 `INTERNAL_ERROR` 구조로 래핑됩니다.
- 관련 단위 테스트들을 보강하거나 추가하여 대표 실패 케이스(문서 없음, 권한 오류, 표 인덱스 오류, MCP 에러 변환)를 검증하도록 수정했습니다.

### Testing
- 코드 컴파일 검증: `python -m compileall -q src tests` — 성공했습니다.
- 선택적 단위 테스트 실행: `pytest -q tests/test_hwpx_ops.py tests/test_mcp_end_to_end.py::test_failure_paths_raise_runtime_errors tests/test_mcp_end_to_end.py::test_table_index_error_has_explicit_code tests/test_mcp_end_to_end.py::test_resource_handler_returns_standard_error_for_unknown_handle tests/test_mcp_end_to_end.py::test_call_tool_returns_mcp_error_payload` — 실행된 테스트들이 통과했으며 (비공개/구현 노출 방식에 따라) 일부 테스트는 환경에 따라 `skip` 처리될 수 있습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d523683083218e36bc2fc6e87a25)