### PR TITLE
문서 handle 레지스트리를 일반 도구 경로로 확장하고 교차 문서 표 복사 도구 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,21 +130,29 @@ uvx hwpx-mcp-server --transport streamable-http --host 0.0.0.0 --port 8080
   }
   ```
 
-- **사전 등록된 핸들 사용** — 하드닝 파이프라인에서 이미 로드된 문서에 대해 후속 검색/컨텍스트/편집을 수행할 때는 `handleId`를 전달하면 됩니다.
+- **사전 등록된 핸들 사용** — 이제 일반 도구(`open_info`, `read_text`, `set_table_cell_text` 등)도 `handleId`를 공식 지원합니다.
 
   ```jsonc
   {
-    "name": "hwpx.plan_edit",
+    "name": "open_info",
     "arguments": {
       "type": "handle",
-      "handleId": "doc-1234",
-      "operations": [
-        {
-          "target": {"nodeId": "n_deadbeef"},
-          "match": "needle",
-          "replacement": "haystack"
-        }
-      ]
+      "handleId": "h_0123456789abcdef"
+    }
+  }
+  ```
+
+- **멀티 문서 교차 작업 예시** — 문서 A의 표를 문서 B로 복사하는 흐름입니다.
+
+  ```jsonc
+  {
+    "name": "copy_table_between_documents",
+    "arguments": {
+      "sourceDocument": {"type": "handle", "handleId": "h_source"},
+      "sourceTableIndex": 0,
+      "targetDocument": {"type": "handle", "handleId": "h_target"},
+      "targetSectionIndex": 0,
+      "autoFit": true
     }
   }
   ```
@@ -480,6 +488,23 @@ python -m pytest
 }
 ```
 
+## 🗂️ 문서 Handle Registry 도구 및 세션 수명 정책
+
+### 신규 도구
+
+- `open_document_handle`: 로케이터(path/uri/handleId)를 등록하고 표준 `handle` 객체를 반환
+- `list_open_documents`: 현재 프로세스에 등록된 handle 목록과 세션 정책(`sessionPolicy`) 반환
+- `close_document_handle`: 특정 handle을 레지스트리에서 해제
+- `copy_table_between_documents`: 문서 A의 표를 읽어 문서 B에 복사(교차 문서 작업)
+
+### 세션 수명 정책
+
+- **레지스트리 범위**: 프로세스 단위(`registryScope=process`)
+- **요청 처리 단위**: 요청 단위(`requestScope=request`) — 각 MCP 요청은 독립 실행되지만, handle 레지스트리는 프로세스 내에서 유지
+- **캐시/레지스트리 해제 조건**
+  1. `close_document_handle` 호출 시 해당 handle 즉시 해제
+  2. 서버 프로세스 종료/재시작 시 전체 레지스트리 해제
+
 ## 📚 Resources 사용 예시 및 URI 계약
 
 MCP Resources를 통해 **등록된 handle 기반 읽기 전용 조회**를 사용할 수 있습니다. 서버는 도구 호출 과정에서 실제 문서 경로를 해석할 때 handle을 자동 등록하며, `resources/list`에서는 현재 등록된 handle만 노출합니다.
@@ -494,7 +519,7 @@ MCP Resources를 통해 **등록된 handle 기반 읽기 전용 조회**를 사�
 
 ### 호출 흐름 예시
 
-1. 먼저 도구(예: `open_info`, `read_text`)를 호출해 문서를 열면 해당 문서 handle이 등록됩니다.
+1. 먼저 `open_document_handle`(또는 `open_info`/`read_text`)를 호출해 문서를 열면 해당 문서 handle이 등록됩니다.
 2. `resources/list`를 호출하면 해당 handle의 `metadata/paragraphs/tables` URI가 나타납니다.
 3. `resources/read`로 원하는 URI를 읽어 JSON(`application/json`) 본문을 받습니다.
 

--- a/src/hwpx_mcp_server/core/context.py
+++ b/src/hwpx_mcp_server/core/context.py
@@ -85,3 +85,26 @@ def window_for_paragraph(
         "focus": focus,
         "after": after,
     }
+
+
+@dataclass(frozen=True)
+class SessionLifecyclePolicy:
+    """문서 handle 레지스트리 수명 정책."""
+
+    registry_scope: str = "process"
+    request_scope: str = "request"
+    eviction: tuple[str, ...] = (
+        "close_document_handle 호출 시",
+        "프로세스 종료 시",
+    )
+
+    def as_dict(self) -> dict:
+        return {
+            "registryScope": self.registry_scope,
+            "requestScope": self.request_scope,
+            "eviction": list(self.eviction),
+        }
+
+
+def default_session_lifecycle_policy() -> SessionLifecyclePolicy:
+    return SessionLifecyclePolicy()

--- a/tests/test_locator_models.py
+++ b/tests/test_locator_models.py
@@ -1,5 +1,3 @@
-import pytest
-
 from hwpx_mcp_server.core.plan import PlanEditInput
 from hwpx_mcp_server.tools import DocumentLocatorInput
 
@@ -16,11 +14,10 @@ def test_document_locator_input_accepts_uri_variant() -> None:
     assert data["path"] == uri
 
 
-def test_document_locator_handle_requires_explicit_opt_in() -> None:
+def test_document_locator_handle_supports_handle_id_flow() -> None:
     payload = DocumentLocatorInput.model_validate({"type": "handle", "handleId": "doc-123"})
-    with pytest.raises(ValueError):
-        payload.to_hwpx_payload()
-    assert payload.to_hwpx_payload(require_path=False) == {}
+    assert payload.to_hwpx_payload() == {"path": None, "handleId": "doc-123"}
+    assert payload.to_hwpx_payload(require_path=False) == {"handleId": "doc-123"}
 
 
 def test_plan_edit_input_surface_doc_id_for_handle() -> None:

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -74,3 +74,11 @@ def test_convert_hwp_to_hwpx_tool_is_exposed():
 def test_analyze_template_structure_tool_is_exposed():
     names = {definition.name for definition in build_tool_definitions()}
     assert "analyze_template_structure" in names
+
+
+def test_document_handle_tools_are_exposed():
+    names = {definition.name for definition in build_tool_definitions()}
+    assert "open_document_handle" in names
+    assert "list_open_documents" in names
+    assert "close_document_handle" in names
+    assert "copy_table_between_documents" in names


### PR DESCRIPTION
### Motivation
- 기존에는 핸들 기반 흐름이 하드닝 파이프라인 일부 도구에 한정되어 있어 일반 도구에서도 동일한 handle 흐름을 사용하기 어렵습니다. 
- 멀티 문서(교차 문서) 작업 예: 문서 A의 표를 문서 B로 복사하는 유즈케이스를 공식 지원할 필요가 있습니다.
- 세션 단위로 등록된 문서 핸들의 수명과 노출 정책을 문서화하여 클라이언트가 레지스트리 동작을 예측할 수 있게 합니다.

### Description
- `DocumentLocatorInput.to_hwpx_payload`를 확장해 `handleId` 흐름을 공식 지원하도록 변경하고, `_simple` 호출 경로에서 `handleId → path`를 해석하도록 구현했습니다 (`src/hwpx_mcp_server/tools.py`).
- `HwpxOps`에 핸들 관리 API를 추가했습니다: `open_document_handle`, `list_open_documents`, `close_document_handle`, `resolve_document_path` 및 교차 문서 표 복사 연산 `copy_table_between_documents`를 구현했습니다 (`src/hwpx_mcp_server/hwpx_ops.py`).
- 도구 등록부에 다음 신규 도구들을 추가했습니다: `open_document_handle`, `list_open_documents`, `close_document_handle`, `copy_table_between_documents` 및 관련 입력/출력 Pydantic 모델들 (`src/hwpx_mcp_server/tools.py`).
- 세션 수명 정책 모델 `SessionLifecyclePolicy`를 `core/context.py`에 추가하고 `list_open_documents` 응답에 `sessionPolicy`를 포함하도록 했습니다 (`src/hwpx_mcp_server/core/context.py`).
- README에 멀티문서 시나리오(문서 A→문서 B 표 복사), 신규 도구 설명 및 세션 수명 정책(프로세스/요청 단위 및 해제 조건)을 한글로 문서화했습니다 (`README.md`).
- 교차 문서 작업과 handle 흐름을 검증하는 단위 테스트를 추가/갱신했습니다: `tests/test_hwpx_ops.py`, `tests/test_locator_models.py`, `tests/test_tool_schemas.py`에 관련 케이스를 포함했습니다.

### Testing
- 실행한 자동화 테스트: `pytest -q tests/test_locator_models.py tests/test_tool_schemas.py tests/test_hwpx_ops.py`.
- 결과: 모든 테스트가 통과했습니다 (해당 명령으로 세 파일의 테스트가 성공적으로 완료됨).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d67830c48321bba6ff0b42272f43)