### PR TITLE
CI/배포 GitHub Actions 워크플로우 추가 및 README 배지 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Python ${{ matrix.python-version }} 설정
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: 의존성 설치
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+
+      - name: pytest 실행
+        run: pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Python 설정
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 빌드/검증 도구 설치
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+          pip install build twine
+
+      - name: 테스트 실행
+        run: pytest
+
+      - name: 패키지 빌드
+        run: python -m build
+
+      - name: 패키지 무결성 검사
+        run: python -m twine check dist/*
+
+      - name: PyPI 배포 (API 토큰)
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: PyPI 배포 (Trusted Publisher)
+        if: ${{ secrets.PYPI_API_TOKEN == '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 이 프로젝트는 **한글 MCP(HWPX) 서버**로, HWPX 문서를 한글 워드프로세서 없이 직접 열고 자동화할 수 있도록 설계되었습니다.  
 Gemini CLI, Claude Desktop과 같은 MCP 클라이언트에 연결하여 문서 생성·편집·탐색 기능을 제공합니다.
 
-[](https://www.google.com/search?q=https://pypi.org/project/hwpx-mcp-server/)
-[](https://opensource.org/licenses/MIT)
-[](https://www.google.com/search?q=https://github.com/your-repo/hwpx-mcp-server/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/hwpx-mcp-server.svg)](https://pypi.org/project/hwpx-mcp-server/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI 워크플로](https://img.shields.io/badge/workflow-CI-blue)](./.github/workflows/ci.yml)
+[![Publish 워크플로](https://img.shields.io/badge/workflow-Publish-blueviolet)](./.github/workflows/publish.yml)
 
 **순수 파이썬으로 HWPX 문서를 자유롭게 다루는 가장 강력한 방법.**
 


### PR DESCRIPTION
### Motivation
- 저장소에 자동화된 CI가 없어 푸시/PR 시 `pytest` 검증을 자동화하려고 변경했습니다.
- 태그 푸시 시 빌드·검증을 거쳐 PyPI로 안전하게 배포하도록 Publish 워크플로우를 추가하려는 의도입니다.
- 문서의 배지 링크가 실제 워크플로우 파일을 가리키지 않아 README의 배지 경로를 정리했습니다.

### Description
- `.github/workflows/ci.yml` 파일을 추가하여 `push`/`pull_request` 이벤트에서 Python 매트릭스(`3.10`, `3.11`, `3.12`)로 `pip install -e .[test]` 후 `pytest`를 실행하도록 구성했습니다.
- `.github/workflows/publish.yml` 파일을 추가하여 태그 푸시(`v*`, `X.Y.Z`) 시 `pip install -e .[test]`, `pytest`, `python -m build`, `python -m twine check dist/*` 순으로 검증한 후 조건에 따라 PyPI로 배포하도록 구성했습니다.
- Publish 워크플로우는 `PYPI_API_TOKEN`이 설정되어 있으면 토큰 기반 배포를 사용하고, 토큰이 없을 경우 Trusted Publisher 흐름(id-token)을 사용하도록 분기 처리했습니다.
- `README.md`의 상단 배지를 실제 워크플로우 파일 경로(`./.github/workflows/ci.yml`, `./.github/workflows/publish.yml`)로 교체하고 PyPI/라이선스 배지를 추가했습니다.

### Testing
- `pip install -e .[test]`를 사용해 테스트 의존성을 설치했고 `pytest`를 실행했으며 결과는 `73 passed, 1 failed, 1 skipped`로 단일 테스트가 실패했습니다 (`tests/test_mcp_end_to_end.py::test_tool_schemas_are_sanitized`).
- `python -m pip install build twine` 명령은 성공적으로 실행되었습니다.
- `python -m build` 및 `python -m twine check dist/*`는 빌드와 패키지 무결성 검사에서 모두 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d8a083448321bd7b84237bda9eb7)