### PR TITLE
python-hwpx 2.0 회귀 회피를 위한 의존성 상한 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 uvx hwpx-mcp-server
 ```
 
-> `python-hwpx >= 1.9` 이상이 필요하며, 첫 실행 시 자동 설치됩니다.
+> `python-hwpx >= 1.9, < 2.0` 버전이 필요하며, 첫 실행 시 자동 설치됩니다.
 
 ### 2. MCP 클라이언트 설정
 
@@ -327,7 +327,7 @@ hwpx-mcp-server
 └── pyproject.toml
 ```
 
-- **순수 파이썬**: `python-hwpx >= 1.9` · `mcp` · `anyio` · `pydantic`
+- **순수 파이썬**: `python-hwpx >= 1.9, < 2.0` · `mcp` · `anyio` · `pydantic`
 - **경로 해석**: 서버 실행 디렉터리 기준, 별도 설정 불필요
 - **안전 장치**: 파괴적 작업에 `dryRun` 플래그 우선 제공 · 자동 `.bak` 백업
 - **스키마**: draft-07 호환 Sanitizer를 거쳐 `$ref` / `anyOf` 없이 평탄화

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hwpx-mcp-server"
-version = "0.4.5"
+version = "0.4.6"
 description = "Model Context Protocol server for local HWPX document automation."
 readme = "README.md"
 authors = [{ name = "Kohkyuhyun" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-    "python-hwpx>=1.9",
+    "python-hwpx>=1.9,<2.0",
     "pydantic>=2.7",
     "anyio>=4.0",
     "mcp>=1.14.1",


### PR DESCRIPTION
### Motivation
- `python-hwpx` 2.0에서 `hwpx.document` import 시 `ET` 미정의 오류로 서버 시작 시 크래시가 발생하므로 이를 회피하기 위해 의존성 상한을 추가했습니다.

### Description
- `pyproject.toml`의 패키지 버전을 `0.4.6`으로 올리고 `python-hwpx` 의존성을 `>=1.9,<2.0`로 제한했으며, 동일한 변경을 `README.md`의 설치 요구사항에도 반영했습니다.

### Testing
- 자동화 검증으로 `pytest`를 실행한 결과 `73 passed, 1 failed, 1 skipped`(`tests/test_mcp_end_to_end.py::test_tool_schemas_are_sanitized` 실패)였고, `pyproject.toml` 파싱으로 의존성 항목이 `python-hwpx>=1.9,<2.0`으로 반영된 것을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ddfa9d6c8321831642568d1597e3)