### PR TITLE
feat: Phase 2 콘텐츠 CRUD 도구 11종 및 core/content 구현

### DIFF
--- a/src/hwpx_mcp_server/core/content.py
+++ b/src/hwpx_mcp_server/core/content.py
@@ -1,14 +1,16 @@
+"""문단, 표, 메모 CRUD 로직."""
+
 from __future__ import annotations
 
+import logging
 from typing import Any
 
+from hwpx.document import HwpxDocument
 
-def iter_all_paragraphs(doc: Any):
-    for paragraph in doc.paragraphs:
-        yield paragraph
+logger = logging.getLogger(__name__)
 
 
-def _iter_tables(doc: Any):
+def _iter_tables(doc: HwpxDocument):
     seen: set[int] = set()
     for paragraph in doc.paragraphs:
         for table in getattr(paragraph, "tables", []):
@@ -16,6 +18,172 @@ def _iter_tables(doc: Any):
             if key not in seen:
                 seen.add(key)
                 yield table
+
+
+def _resolve_style(style: str | None) -> str | None:
+    if style is None:
+        return None
+    value = style.strip()
+    return value or None
+
+
+def _ensure_lxml_et_for_memo() -> None:
+    """python-hwpx memo API의 ET 타입 불일치를 보정한다."""
+    import hwpx.oxml.document as oxml_document
+    from lxml import etree
+
+    oxml_document.ET = etree
+
+
+# ── 문단 ──────────────────────────────────────────────
+
+def add_heading_to_doc(doc: HwpxDocument, text: str, level: int = 1) -> int:
+    """문서 끝에 제목(헤딩) 문단을 추가한다. 추가된 paragraph_index를 반환."""
+    safe_level = min(6, max(1, int(level)))
+    stripped = (text or "").strip()
+    heading_text = stripped if stripped.startswith("#") else f"{'#' * safe_level} {stripped}"
+    doc.add_paragraph(heading_text)
+    return len(doc.paragraphs) - 1
+
+
+def add_paragraph_to_doc(doc: HwpxDocument, text: str, style: str = None) -> int:
+    """문서 끝에 일반 문단을 추가한다. 추가된 paragraph_index를 반환."""
+    style_id = _resolve_style(style)
+    doc.add_paragraph(text or "", style_id_ref=style_id)
+    return len(doc.paragraphs) - 1
+
+
+def insert_paragraph_to_doc(doc: HwpxDocument, paragraph_index: int, text: str, style: str = None) -> int:
+    """지정 위치 앞에 문단을 삽입한다. 삽입된 paragraph_index를 반환."""
+    total = len(doc.paragraphs)
+    if paragraph_index < 0 or paragraph_index > total:
+        raise ValueError(f"유효하지 않은 paragraph_index: {paragraph_index}")
+
+    if paragraph_index == total:
+        return add_paragraph_to_doc(doc, text, style)
+
+    target = doc.paragraphs[paragraph_index]
+    style_id = _resolve_style(style)
+    inserted = target.section.add_paragraph(text or "", style_id_ref=style_id)
+
+    target_parent = target.element.getparent()
+    if target_parent is None:
+        raise RuntimeError("대상 문단의 부모 요소를 찾을 수 없습니다.")
+
+    inserted_parent = inserted.element.getparent()
+    if inserted_parent is None:
+        raise RuntimeError("삽입 문단의 부모 요소를 찾을 수 없습니다.")
+
+    inserted_parent.remove(inserted.element)
+    target_parent.insert(target_parent.index(target.element), inserted.element)
+    return paragraph_index
+
+
+def delete_paragraph_from_doc(doc: HwpxDocument, paragraph_index: int) -> int:
+    """지정 문단 내용을 비워 삭제 효과를 낸다. 남은 문단 수를 반환."""
+    paragraphs = doc.paragraphs
+    total = len(paragraphs)
+    if paragraph_index < 0 or paragraph_index >= total:
+        raise ValueError(f"유효하지 않은 paragraph_index: {paragraph_index}")
+    target = paragraphs[paragraph_index]
+    for run in target.runs:
+        run.text = ""
+    for table in getattr(target, "tables", []):
+        for row in table.rows:
+            for cell in row.cells:
+                cell.text = ""
+    return total
+
+
+# ── 표 ────────────────────────────────────────────────
+
+def add_table_to_doc(doc: HwpxDocument, rows: int, cols: int, data: list[list[str]] = None) -> int:
+    """문서 끝에 표를 추가한다. 추가된 table_index를 반환."""
+    if rows <= 0 or cols <= 0:
+        raise ValueError("rows와 cols는 1 이상이어야 합니다.")
+    table = doc.add_table(rows=rows, cols=cols)
+    payload = data or []
+    for r in range(min(rows, len(payload))):
+        row_data = payload[r] or []
+        for c in range(min(cols, len(row_data))):
+            table.rows[r].cells[c].text = str(row_data[c])
+    return len(list(_iter_tables(doc))) - 1
+
+
+def get_table_data(doc: HwpxDocument, table_index: int) -> dict:
+    """표의 모든 셀 텍스트를 2D 배열로 반환한다."""
+    tables = list(_iter_tables(doc))
+    if table_index < 0 or table_index >= len(tables):
+        raise ValueError(f"유효하지 않은 table_index: {table_index}")
+    table = tables[table_index]
+    data = [[cell.text or "" for cell in row.cells] for row in table.rows]
+    rows = len(data)
+    cols = len(data[0]) if data else 0
+    return {"rows": rows, "cols": cols, "data": data}
+
+
+def set_cell_text(doc: HwpxDocument, table_index: int, row: int, col: int, text: str) -> None:
+    """표의 특정 셀 텍스트를 변경한다."""
+    tables = list(_iter_tables(doc))
+    if table_index < 0 or table_index >= len(tables):
+        raise ValueError(f"유효하지 않은 table_index: {table_index}")
+    table = tables[table_index]
+    if row < 0 or row >= len(table.rows):
+        raise ValueError(f"유효하지 않은 row: {row}")
+    if col < 0 or col >= len(table.rows[row].cells):
+        raise ValueError(f"유효하지 않은 col: {col}")
+    table.rows[row].cells[col].text = text or ""
+
+
+# ── 메모 ──────────────────────────────────────────────
+
+def add_memo_to_doc(doc: HwpxDocument, paragraph_index: int, text: str) -> None:
+    """문단에 메모를 추가한다."""
+    paragraphs = doc.paragraphs
+    if paragraph_index < 0 or paragraph_index >= len(paragraphs):
+        raise ValueError(f"유효하지 않은 paragraph_index: {paragraph_index}")
+
+    _ensure_lxml_et_for_memo()
+    paragraph = paragraphs[paragraph_index]
+    doc.add_memo_with_anchor(text or "", paragraph=paragraph)
+
+
+def remove_memo_from_doc(doc: HwpxDocument, paragraph_index: int) -> None:
+    """문단의 메모를 제거한다."""
+    paragraphs = doc.paragraphs
+    if paragraph_index < 0 or paragraph_index >= len(paragraphs):
+        raise ValueError(f"유효하지 않은 paragraph_index: {paragraph_index}")
+    paragraph = paragraphs[paragraph_index]
+
+    memo_ids: set[str] = set()
+    for run in paragraph.runs:
+        for ctrl in run.element.findall("{http://www.hancom.co.kr/hwpml/2011/paragraph}ctrl"):
+            field_begin = ctrl.find("{http://www.hancom.co.kr/hwpml/2011/paragraph}fieldBegin")
+            if field_begin is None:
+                continue
+            command = (field_begin.get("command") or "")
+            if "memoId=" in command:
+                memo_id = command.split("memoId=", 1)[1].split(";", 1)[0].strip()
+                if memo_id:
+                    memo_ids.add(memo_id)
+
+    for memo in list(doc.memos):
+        if memo.id in memo_ids:
+            doc.remove_memo(memo)
+
+
+# ── 페이지 ────────────────────────────────────────────
+
+def add_page_break_to_doc(doc: HwpxDocument) -> None:
+    """문서 끝에 페이지 나누기를 추가한다."""
+    doc.add_paragraph("", pageBreak="1")
+
+
+# ── 텍스트 수집 ───────────────────────────────────────
+
+def iter_all_paragraphs(doc: Any):
+    for paragraph in doc.paragraphs:
+        yield paragraph
 
 
 def iter_table_texts(doc: Any):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+from hwpx_mcp_server.server import (
+    add_heading,
+    add_memo,
+    add_page_break,
+    add_paragraph,
+    add_table,
+    create_document,
+    delete_paragraph,
+    get_document_outline,
+    get_document_text,
+    get_paragraphs_text,
+    get_table_text,
+    insert_paragraph,
+    list_available_documents,
+    remove_memo,
+    set_table_cell_text,
+)
+
+
+def test_add_paragraph(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    add_paragraph(str(target), "안녕하세요")
+    text_result = get_document_text(str(target))
+
+    assert "안녕하세요" in text_result["text"]
+
+
+def test_add_heading(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    add_heading(str(target), "1장 서론", level=1)
+    outline = get_document_outline(str(target))["outline"]
+
+    assert any(item["level"] == 1 and "1장 서론" in item["text"] for item in outline)
+
+
+def test_insert_paragraph(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    add_paragraph(str(target), "첫 문단")
+    add_paragraph(str(target), "둘 문단")
+    add_paragraph(str(target), "셋 문단")
+
+    insert_paragraph(str(target), 1, "삽입 문단")
+    rows = get_paragraphs_text(str(target), 0, 6)["paragraphs"]
+    texts = [entry["text"] for entry in rows]
+
+    assert texts.index("삽입 문단") < texts.index("둘 문단")
+
+
+def test_delete_paragraph(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    add_paragraph(str(target), "삭제 대상")
+    before = len(get_paragraphs_text(str(target))["paragraphs"])
+    result = delete_paragraph(str(target), 1)
+    after = len(get_paragraphs_text(str(target))["paragraphs"])
+
+    assert result["remaining_paragraphs"] == after
+    assert after == before
+    texts = [entry["text"] for entry in get_paragraphs_text(str(target))["paragraphs"]]
+    assert "삭제 대상" not in texts
+
+
+def test_add_table(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    add_table(str(target), 2, 3, [["A", "B", "C"], ["1", "2", "3"]])
+    table = get_table_text(str(target), table_index=0)
+
+    assert table["data"][0] == ["A", "B", "C"]
+
+
+def test_set_table_cell_text(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    add_table(str(target), 1, 1, [["초기값"]])
+    set_table_cell_text(str(target), 0, 0, 0, "변경값")
+    table = get_table_text(str(target), 0)
+
+    assert table["data"][0][0] == "변경값"
+
+
+def test_add_and_remove_memo(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    add_paragraph(str(target), "메모 대상")
+    added = add_memo(str(target), 1, "검토 필요")
+    removed = remove_memo(str(target), 1)
+
+    assert added["memo_added"] is True
+    assert removed["memo_removed"] is True
+
+
+def test_add_page_break(tmp_path: Path):
+    target = tmp_path / "test.hwpx"
+    create_document(str(target))
+
+    result = add_page_break(str(target))
+
+    assert result["success"] is True
+
+
+def test_list_available_documents(tmp_path: Path):
+    create_document(str(tmp_path / "test1.hwpx"))
+    create_document(str(tmp_path / "test2.hwpx"))
+
+    result = list_available_documents(str(tmp_path))
+
+    assert result["count"] == 2
+    names = {entry["filename"] for entry in result["documents"]}
+    assert {"test1.hwpx", "test2.hwpx"}.issubset(names)


### PR DESCRIPTION
### Motivation
- Phase 2 요구사항에 따라 HWPX 문서의 문단·표·메모·페이지 관련 CRUD를 서버 도구로 제공하기 위해 `core/content.py`와 도구 등록을 추가했습니다.
- 기존 Phase 1의 상태(문서 열기/저장, 검색 등)를 재사용하면서 독립적(stateless) 호출 규칙을 지키기 위함입니다.

### Description
- 신규 모듈 `src/hwpx_mcp_server/core/content.py`를 구현하여 문단/표/메모/페이지 조작 함수를 추가했습니다: `add_heading_to_doc`, `add_paragraph_to_doc`, `insert_paragraph_to_doc`, `delete_paragraph_from_doc` (내용 비우기 방식), `add_table_to_doc`, `get_table_data`, `set_cell_text`, `add_memo_to_doc`, `remove_memo_from_doc`, `add_page_break_to_doc`, `collect_full_text` 유지 및 보완.
- `src/hwpx_mcp_server/server.py`에 위 기능을 바인딩하는 11개 MCP 도구를 등록했습니다: `add_heading`, `add_paragraph`, `insert_paragraph`, `delete_paragraph`, `add_table`, `get_table_text`, `set_table_cell_text`, `add_page_break`, `add_memo`, `remove_memo`, `list_available_documents`.
- 구현상 제약 처리: python-hwpx의 메모(코멘트) API와 ET 타입 불일치 문제를 완화하기 위해 메모 추가 시 내부 ET 바인딩을 `lxml.etree`로 보정하는 소규모 호환 패치를 적용했습니다.
- 문단 삭제는 python-hwpx의 물리적 삭제가 저장 시 일관되게 반영되지 않는 케이스를 고려해 대상 문단의 내용을 비우는 방식으로 삭제 효과를 내도록 구현했습니다.
- 테스트용 파일 `tests/test_content.py`를 추가하여 문단/헤딩 추가, 삽입, 삭제(내용 비우기 방식 검증), 표 생성/셀 수정, 메모 추가/제거, 페이지 나누기, 디렉토리 문서 목록을 검증하도록 구성했습니다.

### Testing
- 실행한 자동화 테스트: `pytest -q tests/test_content.py tests/test_search.py`를 수행했으며 모든 테스트가 통과했습니다 (성공).
- 테스트는 `create_document` → 각 도구 호출 → `get_document_text`/`get_paragraphs_text`/`get_table_text` 등으로 결과를 검증하는 방식으로 작성되었습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999eb3a4d888321821bd5504e57379d)