### PR TITLE
chore: require python-hwpx>=2.5 (split_merged_cell fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ authors = [{ name = "Kohkyuhyun" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-    "python-hwpx>=2.4",
+    "python-hwpx>=2.5", # split_merged_cell ET/lxml 호환성 크래시 fix 포함
+
     "pydantic>=2.7",
     "anyio>=4.0",
     "mcp>=1.14.1",


### PR DESCRIPTION
- Bump dependency to python-hwpx>=2.5 to pick up split_merged_cell ET/lxml compatibility fix\n- Stabilize tests by ensuring inherited HWPX_MCP_SANDBOX_ROOT does not break tmp-path unit tests (subprocess traversal sandboxing remains enabled)\n- pytest passes locally