### PR TITLE
feat: add save verification report

### DIFF
--- a/src/hwpx_mcp_server.egg-info/SOURCES.txt
+++ b/src/hwpx_mcp_server.egg-info/SOURCES.txt
@@ -50,6 +50,7 @@ tests/test_locator_models.py
 tests/test_mcp_end_to_end.py
 tests/test_pipeline.py
 tests/test_read_export_tools.py
+tests/test_save_verification_report.py
 tests/test_search.py
 tests/test_streamable_http_transport.py
 tests/test_tool_schemas.py

--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -362,9 +362,9 @@ class HwpxOps:
                 paragraphs.append(paragraph.text(preserve_breaks=True))
         self._plan_manager.register_document(doc_id, "\n".join(paragraphs))
 
-    def _save_document(self, document: HwpxDocument, target: Path) -> None:
+    def _save_document(self, document: HwpxDocument, target: Path) -> Dict[str, Any]:
         try:
-            self.storage.save_document(document, target)
+            return self.storage.save_document(document, target)
         except PermissionError as exc:
             raise self._new_error(
                 "PERMISSION_DENIED",
@@ -1948,14 +1948,14 @@ class HwpxOps:
     # ------------------------------------------------------------------
     def save(self, path: str) -> Dict[str, Any]:
         document, resolved = self._open_document(path)
-        self._save_document(document, resolved)
-        return {"ok": True}
+        verification_report = self._save_document(document, resolved)
+        return {"ok": True, "verificationReport": verification_report}
 
     def save_as(self, path: str, out: str) -> Dict[str, Any]:
         document, resolved = self._open_document(path)
         out_path = self._resolve_output_path(out)
-        self._save_document(document, out_path)
-        return {"outPath": str(out_path)}
+        verification_report = self._save_document(document, out_path)
+        return {"outPath": str(out_path), "verificationReport": verification_report}
 
     def fill_template(
         self,

--- a/src/hwpx_mcp_server/storage.py
+++ b/src/hwpx_mcp_server/storage.py
@@ -4,14 +4,33 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import tempfile
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Mapping, Optional, Protocol, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Tuple
 from urllib import error, parse, request
 
 from .upstream import HwpxDocument, open_document
+
+_REQUIRED_HWPX_FILES = [
+    "mimetype",
+    "Contents/content.hpf",
+    "Contents/header.xml",
+    "Contents/section0.xml",
+]
+_SECTION_XML_RE = re.compile(r"^Contents/section\d+\.xml$")
+_PLACEHOLDER_PATTERNS = [
+    re.compile(r"\[[^\[\]\n]{1,100}\]"),
+    re.compile(r"\[\[[^\[\]\n]{1,100}\]\]"),
+    re.compile(r"\{\{[^{}\n]{1,100}\}\}"),
+    re.compile(r"__[^_\n]{1,100}__"),
+]
+_UNESCAPED_AMP_RE = re.compile(r"&(?!amp;|lt;|gt;|quot;|apos;|#\d+;|#x[0-9A-Fa-f]+;)")
+_NESTED_OPENING_TAG_RE = re.compile(r"<hp:t\b[^>]*>[^<]*(<(?!/?hp:)[^>]+>)")
+_EMPTY_HP_T_RE = re.compile(r"<hp:t\b[^>]*>\s*</hp:t>")
 
 
 class DocumentStorage(Protocol):
@@ -37,7 +56,7 @@ class DocumentStorage(Protocol):
     def open_document(self, path: str) -> Tuple[HwpxDocument, Path]:
         """Open the document located at *path* and return it with the resolved path."""
 
-    def save_document(self, document: HwpxDocument, target: Path) -> None:
+    def save_document(self, document: HwpxDocument, target: Path) -> Dict[str, Any]:
         """Persist *document* to *target* using backend specific rules."""
 
 
@@ -98,8 +117,9 @@ class LocalDocumentStorage:
         document = open_document(resolved)
         return document, resolved
 
-    def save_document(self, document: HwpxDocument, target: Path) -> None:
+    def save_document(self, document: HwpxDocument, target: Path) -> Dict[str, Any]:
         self.maybe_backup(target)
+        pre_save_snapshot = build_hwpx_presave_snapshot(target)
         # Atomic save: write to a sibling temp file, verify it, then replace.
         tmp_fd, tmp_path_str = tempfile.mkstemp(
             suffix=target.suffix, dir=str(target.parent)
@@ -109,7 +129,9 @@ class LocalDocumentStorage:
             os.close(tmp_fd)
             document.save_to_path(tmp_path)
             open_document(tmp_path)
+            verification_report = build_hwpx_verification_report(tmp_path, pre_save_snapshot)
             os.replace(tmp_path, target)
+            return verification_report
         except Exception:
             tmp_path.unlink(missing_ok=True)
             raise
@@ -227,16 +249,19 @@ class HttpDocumentStorage:
         document = open_document(local_path)
         return document, Path(path)
 
-    def save_document(self, document: HwpxDocument, target: Path) -> None:
+    def save_document(self, document: HwpxDocument, target: Path) -> Dict[str, Any]:
         remote_key = str(target)
         cache_path = self._cache.get(remote_key)
         if cache_path is None:
             cache_path = self._cache_path(remote_key)
             self._cache[remote_key] = cache_path
 
+        pre_save_snapshot = build_hwpx_presave_snapshot(cache_path if cache_path.exists() else None)
+
         try:
             document.save_to_path(cache_path)
             payload = cache_path.read_bytes()
+            verification_report = build_hwpx_verification_report(cache_path, pre_save_snapshot)
         except Exception as exc:  # pragma: no cover - unexpected save error
             raise RuntimeError(f"HTTP storage save failed: {exc}") from exc
 
@@ -244,9 +269,148 @@ class HttpDocumentStorage:
             self._client.upload(remote_key, payload)
         except Exception as exc:  # pragma: no cover - handled in tests for fake clients
             raise RuntimeError(f"HTTP storage save failed: {exc}") from exc
+        return verification_report
 
     def _cache_path(self, path: str) -> Path:
         suffix = Path(path).suffix or ".hwpx"
         safe_name = parse.quote_plus(path)
         filename = safe_name if safe_name.endswith(suffix) else f"{safe_name}{suffix}"
         return self._cache_dir / filename
+
+
+def build_hwpx_presave_snapshot(path: Path | None) -> Dict[str, Any] | None:
+    if path is None or not path.exists():
+        return None
+    return _collect_hwpx_snapshot(path)
+
+
+def build_hwpx_verification_report(path: Path, pre_save_snapshot: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    snapshot = _collect_hwpx_snapshot(path)
+    totals = snapshot["totals"]
+    missing_files = snapshot["missing_files"]
+    warnings: List[str] = []
+    if missing_files:
+        warnings.append(f"missing required files: {', '.join(missing_files)}")
+    if totals["placeholders"]:
+        warnings.append("placeholder-like tokens remain in saved document")
+    if totals["suspiciousPatterns"]:
+        warnings.append("suspicious XML/text patterns detected in saved document")
+
+    diff_summary = {
+        "xmlLength": 0,
+        "hpTabs": 0,
+        "paragraphs": 0,
+        "tables": 0,
+    }
+    if pre_save_snapshot is not None:
+        before = pre_save_snapshot["totals"]
+        diff_summary = {
+            "xmlLength": totals["xmlLength"] - before["xmlLength"],
+            "hpTabs": totals["hpTabs"] - before["hpTabs"],
+            "paragraphs": totals["paragraphs"] - before["paragraphs"],
+            "tables": totals["tables"] - before["tables"],
+        }
+
+    ok = not missing_files and not totals["placeholders"] and not totals["suspiciousPatterns"]
+    summary = "verification passed"
+    if not ok:
+        summary = "; ".join(warnings) if warnings else "verification failed"
+
+    return {
+        "ok": ok,
+        "summary": summary,
+        "filePath": str(path),
+        "fileSizeBytes": path.stat().st_size,
+        "requiredFilesChecked": list(_REQUIRED_HWPX_FILES),
+        "missingFiles": missing_files,
+        "sectionReports": snapshot["section_reports"],
+        "totals": {
+            "sections": totals["sections"],
+            "xmlLength": totals["xmlLength"],
+            "hpTabs": totals["hpTabs"],
+            "paragraphs": totals["paragraphs"],
+            "tables": totals["tables"],
+            "placeholders": totals["placeholders"],
+            "suspiciousPatterns": totals["suspiciousPatterns"],
+        },
+        "diffSummary": diff_summary,
+        "warnings": warnings,
+    }
+
+
+def _collect_hwpx_snapshot(path: Path) -> Dict[str, Any]:
+    missing_files: List[str] = []
+    section_reports: List[Dict[str, Any]] = []
+    totals = {
+        "sections": 0,
+        "xmlLength": 0,
+        "hpTabs": 0,
+        "paragraphs": 0,
+        "tables": 0,
+        "placeholders": 0,
+        "suspiciousPatterns": 0,
+    }
+
+    with zipfile.ZipFile(path) as archive:
+        names = set(archive.namelist())
+        for required in _REQUIRED_HWPX_FILES:
+            if required not in names:
+                missing_files.append(required)
+
+        section_names = sorted(name for name in names if _SECTION_XML_RE.match(name))
+        totals["sections"] = len(section_names)
+        for section_name in section_names:
+            xml_text = archive.read(section_name).decode("utf-8", errors="replace")
+            section_index = int(section_name.removeprefix("Contents/section").removesuffix(".xml"))
+            placeholder_examples: List[str] = []
+            placeholder_count = 0
+            for pattern in _PLACEHOLDER_PATTERNS:
+                for match in pattern.findall(xml_text):
+                    placeholder_count += 1
+                    if match not in placeholder_examples and len(placeholder_examples) < 5:
+                        placeholder_examples.append(match)
+
+            suspicious_patterns: List[str] = []
+            if _UNESCAPED_AMP_RE.search(xml_text):
+                suspicious_patterns.append("unescaped_ampersand")
+            if _EMPTY_HP_T_RE.search(xml_text):
+                suspicious_patterns.append("empty_hp_t")
+            if _NESTED_OPENING_TAG_RE.search(xml_text):
+                suspicious_patterns.append("nested_opening_tag_in_text")
+            if ">>" in xml_text or "<<" in xml_text:
+                suspicious_patterns.append("double_angle_marker")
+
+            paragraph_count = xml_text.count("<hp:p")
+            table_count = xml_text.count("<hp:tbl")
+            hp_tab_count = xml_text.count("<hp:tab")
+            xml_length = len(xml_text)
+
+            totals["xmlLength"] += xml_length
+            totals["hpTabs"] += hp_tab_count
+            totals["paragraphs"] += paragraph_count
+            totals["tables"] += table_count
+            totals["placeholders"] += placeholder_count
+            totals["suspiciousPatterns"] += len(suspicious_patterns)
+
+            section_reports.append(
+                {
+                    "section": section_index,
+                    "xmlDeclaration": xml_text.startswith("<?xml"),
+                    "truncatedXml": bool(re.search(r"<[^>]*$", xml_text)),
+                    "brokenTagPattern": bool(re.search(r"<[^>]*<", xml_text)),
+                    "xmlLength": xml_length,
+                    "hpTabs": hp_tab_count,
+                    "paragraphs": paragraph_count,
+                    "tables": table_count,
+                    "placeholderCount": placeholder_count,
+                    "placeholderExamples": placeholder_examples,
+                    "suspiciousPatternCount": len(suspicious_patterns),
+                    "suspiciousPatterns": suspicious_patterns,
+                }
+            )
+
+    return {
+        "missing_files": missing_files,
+        "section_reports": section_reports,
+        "totals": totals,
+    }

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -544,6 +544,7 @@ class CopyTableBetweenDocumentsOutput(_BaseModel):
 
 class SaveOutput(_BaseModel):
     ok: bool
+    verificationReport: Optional[Dict[str, Any]] = None
 
 
 class SaveAsInput(DocumentLocatorInput):
@@ -552,6 +553,7 @@ class SaveAsInput(DocumentLocatorInput):
 
 class OutPathOutput(_BaseModel):
     outPath: str
+    verificationReport: Optional[Dict[str, Any]] = None
 
 
 class ExportOutput(_BaseModel):

--- a/tests/test_save_verification_report.py
+++ b/tests/test_save_verification_report.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from hwpx_mcp_server.core.document import create_blank, open_doc
+from hwpx_mcp_server.hwpx_ops import HwpxOps
+from hwpx_mcp_server.storage import (
+    LocalDocumentStorage,
+    build_hwpx_presave_snapshot,
+    build_hwpx_verification_report,
+)
+
+
+def _write_minimal_hwpx(path: Path, section_xml: str) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("mimetype", "application/hwp+zip")
+        archive.writestr(
+            "Contents/content.hpf",
+            "<?xml version='1.0' encoding='UTF-8'?><hpf:content xmlns:hpf='http://www.hancom.co.kr/schema/2011/hpf' version='1.0'><hpf:metadata/></hpf:content>",
+        )
+        archive.writestr(
+            "Contents/header.xml",
+            "<?xml version='1.0' encoding='UTF-8'?><hh:head xmlns:hh='http://www.hancom.co.kr/hwpml/2011/head'><hh:docInfo/></hh:head>",
+        )
+        archive.writestr("Contents/section0.xml", section_xml)
+        archive.writestr(
+            "[Content_Types].xml",
+            "<?xml version='1.0' encoding='UTF-8'?><Types xmlns='http://schemas.openxmlformats.org/package/2006/content-types'><Default Extension='xml' ContentType='application/xml'/></Types>",
+        )
+
+
+def test_save_verification_report_tracks_pre_post_diff(tmp_path: Path) -> None:
+    target = tmp_path / "verification-clean.hwpx"
+    create_blank(str(target))
+
+    storage = LocalDocumentStorage(base_directory=tmp_path, auto_backup=False)
+    pre_save_snapshot = build_hwpx_presave_snapshot(target)
+
+    doc = open_doc(str(target))
+    doc.add_paragraph("verification paragraph")
+    report = storage.save_document(doc, target)
+
+    assert report["ok"] is True
+    assert report["warnings"] == []
+    assert report["totals"]["paragraphs"] >= 1
+    assert report["diffSummary"]["paragraphs"] >= 1
+    assert pre_save_snapshot is not None
+
+
+def test_save_verification_report_flags_placeholders_and_suspicious_patterns(tmp_path: Path) -> None:
+    target = tmp_path / "verification-suspicious.hwpx"
+    _write_minimal_hwpx(
+        target,
+        """<?xml version='1.0' encoding='UTF-8'?>
+<hs:sec xmlns:hs='http://www.hancom.co.kr/hwpml/2011/section'
+        xmlns:hp='http://www.hancom.co.kr/hwpml/2011/paragraph'>
+  <hp:p id='1'><hp:run><hp:t>[NAME]</hp:t></hp:run></hp:p>
+  <hp:p id='2'><hp:run><hp:t>Tom & Jerry</hp:t></hp:run></hp:p>
+</hs:sec>""",
+    )
+
+    report = build_hwpx_verification_report(target)
+
+    assert report["ok"] is False
+    assert report["totals"]["placeholders"] > 0
+    assert report["totals"]["suspiciousPatterns"] > 0
+    assert any("placeholder-like tokens remain" in warning for warning in report["warnings"])
+    assert any("suspicious XML/text patterns detected" in warning for warning in report["warnings"])
+
+
+def test_save_as_returns_verification_report(tmp_path: Path) -> None:
+    source = tmp_path / "source.hwpx"
+    target = tmp_path / "saved.hwpx"
+    create_blank(str(source))
+
+    ops = HwpxOps(base_directory=tmp_path, auto_backup=False)
+    result = ops.save_as(str(source), str(target))
+
+    assert result["outPath"] == str(target)
+    assert result["verificationReport"]["ok"] is True
+    assert "diffSummary" in result["verificationReport"]


### PR DESCRIPTION
## Summary
- add a structured `verificationReport` to `save` / `save_as`
- capture post-save HWPX verification details: required files, section counts, placeholders, suspicious XML/text patterns, and pre/post diff summary
- add focused tests for clean save, suspicious-pattern detection, and `save_as` response wiring

## Why
The previous PR-1 was based on an older Node-side implementation and could not be reapplied cleanly to the current Python-based `airmang/hwpx-mcp-server` main branch.

This PR reintroduces the same PR-1 intent on the current codebase only:
- stronger post-save verification
- structured save report in the tool response
- no unrelated paragraph/table feature work mixed in

## Verification
- `uv run --extra test pytest tests/test_save_verification_report.py tests/test_formatting.py::test_save_doc_uses_atomic_write_on_failure`
- `uv run --extra test pytest tests/test_hwpx_ops.py::test_save_as_creates_new_file tests/test_tool_schemas.py tests/test_http_storage.py -q`

## Scope guard
This PR is intentionally limited to save verification/report plumbing.
It does **not** include unrelated work such as `delete_paragraphs`, `copy_paragraph_range`, or other exam-editing changes.
