### PR TITLE
docs: reflect save verification report surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+- Document the active public `save` / `save_as` tools in README and workflow docs.
+- Clarify that `save` / `save_as` return a structured post-save `verificationReport` for handoff and review flows.
+- Remove stale release-readiness notes that still treated public `save_as` as deferred.
+
 ## [2.2.4]
 - README를 기존 레이아웃 스타일에 맞춰 정리하고 문서를 한글 중심으로 재정비했습니다.
 - 패키지 소개와 설치, MCP 설정, 주요 도구, 환경 변수 중심으로 문서 구조를 다듬었습니다.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ hwpx-mcp-server
 | `hwpx_to_html` | HWPX 문서를 HTML로 변환 |
 | `hwpx_extract_json` | HWPX 문서를 구조화된 JSON으로 추출 |
 
+### 💾 저장 및 결과 확인
+
+| 도구 | 설명 |
+|---|---|
+| `save` | 현재 문서를 저장하고 `verificationReport`를 반환 |
+| `save_as` | 다른 경로로 저장하고 `outPath`, `verificationReport`를 반환 |
+
+`save`/`save_as`의 `verificationReport`에는 저장 후 구조 점검 결과가 포함됩니다. 예를 들어 필수 파일 존재 여부, 섹션 수, placeholder/의심 패턴 점검, 저장 전후 diff 요약 같은 후속 검증 정보를 자동으로 받을 수 있습니다.
+
 ### 🔬 고급 도구
 
 `HWPX_MCP_ADVANCED=1`일 때 활성화:

--- a/docs/follow-up-roadmap.md
+++ b/docs/follow-up-roadmap.md
@@ -80,7 +80,7 @@ Gate for revisiting any public-tool proposal later:
 
 ## 7. Release Alignment Gates
 
-- Do not cut a release while docs still imply deferred public tools such as `fill_template`, `save_as`, structure diff, or layout-drift reporting on the active FastMCP surface.
+- Do not cut a release while docs still imply deferred public tools such as `fill_template`, structure diff, or layout-drift reporting on the active FastMCP surface, or while `save_as` docs lag behind its real response contract.
 - Keep the layer split explicit in release docs:
   - `python-hwpx` = upstream engine
   - `hwpx-mcp-server` = MCP product surface

--- a/docs/release-readiness-checklist.md
+++ b/docs/release-readiness-checklist.md
@@ -14,7 +14,6 @@ Use this checklist before tagging or publishing a release after the scope-pivot 
   - `compare_reference_structure`
   - `layout_drift_report`
   - `fill_template`
-  - `save_as`
 
 ## 2. Documentation Alignment
 
@@ -40,7 +39,7 @@ Use this checklist before tagging or publishing a release after the scope-pivot 
 - Confirm example skills only rely on existing active MCP tools.
 - Confirm limitations are stated honestly:
   - no public `fill_template`
-  - no public `save_as`
+  - `save_as` docs match the active surface and mention `verificationReport` accurately
   - `plan_edit` / `preview_edit` / `apply_edit` are review-pipeline tools, not a general patch engine
 
 ## 5. Upstream Compatibility

--- a/docs/skill-first-workflows.md
+++ b/docs/skill-first-workflows.md
@@ -21,11 +21,10 @@ Scope for this pass:
 | Preview plans | `preview_edit` | Shows the plan artifact before confirmation. |
 | Apply plans | `apply_edit` | Applies the review pipeline state, not general direct HWPX mutations. |
 | Template fill | `copy_document` + `batch_replace` / `search_and_replace` / `set_table_cell_text` | No public `fill_template` tool on the active FastMCP surface. |
-| Save/copy flows | `copy_document` plus the normal mutating tools | Mutating tools persist immediately through the shared atomic save path. |
+| Save/copy flows | `copy_document`, `save`, `save_as`, plus the normal mutating tools | Mutating tools persist immediately through the shared atomic save path; `save`/`save_as` additionally return a post-save `verificationReport`. |
 
 Important boundary:
 
-- There is no active public `save_as` tool on the FastMCP surface.
 - There is no active public `fill_template` tool on the FastMCP surface.
 - Cautious workflows should edit a copied working file, then promote that file externally after review.
 
@@ -128,7 +127,7 @@ Suggested order:
 
 Why this is the safe path:
 
-- The MCP server does not expose a separate explicit `save` step.
+- The MCP server exposes `save` and `save_as`, both returning a post-save `verificationReport` for explicit handoff checks.
 - Mutations already go through the safer atomic save path, but they still update the target file immediately.
 - Copy-first is therefore the practical review boundary on the current surface.
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -246,7 +246,8 @@ For reference-preserving workflows on the current FastMCP surface, see:
 Current workflow boundary:
 
 - No new public MCP tools are required for these flows.
-- There is no active public `fill_template` or `save_as` tool on the FastMCP surface.
+- There is no active public `fill_template` tool on the FastMCP surface.
+- `save_as` is publicly available and returns a post-save `verificationReport` when you need a copied output plus structured verification details.
 - Use `copy_document` first when you need a reviewable or low-risk edit path because mutating tools persist immediately.
 - Use advanced mode for package inspection and validation steps: `package_parts`, `package_get_xml`, `package_get_text`, `plan_edit`, `preview_edit`, `apply_edit`, `validate_structure`.
 


### PR DESCRIPTION
## Summary
- document the active public `save` / `save_as` tools in the release-facing docs
- explain that both save flows now return a structured `verificationReport` for post-save checks
- remove stale workflow/release notes that still treated public `save_as` as deferred

## Scope
- docs/README/changelog only
- no code changes

## Verification
- checked the active tool surface in `src/hwpx_mcp_server/tools.py`
- checked the response contract in `src/hwpx_mcp_server/hwpx_ops.py`
- checked for stale `save_as`-is-deferred wording across release-facing docs