### PR TITLE
chore: relicense to Apache-2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- License relicensed to Apache-2.0 (sole author, full consent).
+- Previous license terms no longer apply to future releases.
 - Sync downstream docs to the latest local stack validation baseline: `python-hwpx 2.9.0` verified on 2026-04-15, documented minimum support remains `python-hwpx >= 2.6`.
+
+### Added
 - Add stack smoke-test workflow and benchmark follow-up docs under `python-hwpx/shared/hwpx` so the shared HWPX stack baseline lives with the upstream engine repo.
 
 ## [2.2.5]

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,178 @@
-MIT License
+Copyright 2025-2026 airmang (Dr. Wily)
 
-Copyright (c) 2025 HWPX MCP Server
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf of
+   any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+hwpx-mcp-server
+Copyright 2025-2026 airmang
+
+This product includes software developed by airmang.
+Licensed under the Apache License, Version 2.0.
+
+────────────────────────────────────────
+DISCLAIMER — HWPX Format
+
+"HWPX" is the document format specified and trademarked by
+Hancom Inc. (한글과컴퓨터). This project is an independent,
+unofficial implementation and is not affiliated with, endorsed by,
+or sponsored by Hancom Inc.
+────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <p align="center">
     <a href="https://pypi.org/project/hwpx-mcp-server/"><img src="https://img.shields.io/pypi/v/hwpx-mcp-server?style=flat-square&color=blue" alt="PyPI"></a>
     <a href="https://pypi.org/project/hwpx-mcp-server/"><img src="https://img.shields.io/pypi/pyversions/hwpx-mcp-server?style=flat-square" alt="Python"></a>
-    <a href="https://github.com/airmang/hwpx-mcp-server/blob/main/LICENSE"><img src="https://img.shields.io/github/license/airmang/hwpx-mcp-server?style=flat-square" alt="License"></a>
+    <a href="https://github.com/airmang/hwpx-mcp-server/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License"></a>
     <a href="https://github.com/airmang/hwpx-mcp-server/actions"><img src="https://img.shields.io/github/actions/workflow/status/airmang/hwpx-mcp-server/test.yml?style=flat-square&label=tests" alt="Tests"></a>
   </p>
 </p>
@@ -354,9 +354,8 @@ python -m pytest -q
 
 <br>
 
-## 라이선스
-
-[MIT](LICENSE)
+## License
+Apache License 2.0. See LICENSE and NOTICE.
 
 <br>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,17 @@ version = "2.2.5"
 description = "MCP server for reading, editing, inspecting, and validating local HWPX documents with AI agents."
 readme = "README.md"
 authors = [{ name = "Kohkyuhyun" }]
-license = { file = "LICENSE" }
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 requires-python = ">=3.10"
 keywords = ["hwpx", "hancom", "mcp", "model-context-protocol", "document-automation", "ai-agent"]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "python-hwpx>=2.6", # exporters + style helpers used by the current MCP surface
 

--- a/src/hwpx_mcp_server/__init__.py
+++ b/src/hwpx_mcp_server/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HWPX Model Context Protocol 서버 패키지."""
 
 from importlib.metadata import version, PackageNotFoundError

--- a/src/hwpx_mcp_server/compat.py
+++ b/src/hwpx_mcp_server/compat.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """외부 라이브러리 호환성 패치."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/__init__.py
+++ b/src/hwpx_mcp_server/core/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Stateless HWPX 코어 연산."""

--- a/src/hwpx_mcp_server/core/content.py
+++ b/src/hwpx_mcp_server/core/content.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """문단, 표, 메모 CRUD 로직."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/context.py
+++ b/src/hwpx_mcp_server/core/context.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Search and context utilities for hardened tools."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/diff.py
+++ b/src/hwpx_mcp_server/core/diff.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Lightweight helpers for representing logical diffs."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/document.py
+++ b/src/hwpx_mcp_server/core/document.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 from io import BytesIO
 from pathlib import Path

--- a/src/hwpx_mcp_server/core/formatting.py
+++ b/src/hwpx_mcp_server/core/formatting.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Text formatting helpers backed by python-hwpx character/style definitions."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/handles.py
+++ b/src/hwpx_mcp_server/core/handles.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Helpers for generating stable handles for logical nodes."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/locator.py
+++ b/src/hwpx_mcp_server/core/locator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Document locator models used across tool schemas."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/plan.py
+++ b/src/hwpx_mcp_server/core/plan.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Planning pipeline and validation helpers."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/resources.py
+++ b/src/hwpx_mcp_server/core/resources.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """MCP Resource 직렬화 모델."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/core/search.py
+++ b/src/hwpx_mcp_server/core/search.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from typing import Any

--- a/src/hwpx_mcp_server/core/txn.py
+++ b/src/hwpx_mcp_server/core/txn.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Transaction helpers for hardened editing pipeline."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/errors.py
+++ b/src/hwpx_mcp_server/errors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """공통 에러 모델과 MCP 에러 변환 유틸리티."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/hwp_converter.py
+++ b/src/hwpx_mcp_server/hwp_converter.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HWP(.hwp) -> HWPX(.hwpx) 변환 유틸리티."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/hwp_support.py
+++ b/src/hwpx_mcp_server/hwp_support.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HWP(바이너리) 파일의 읽기 전용 텍스트 추출 유틸리티."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/hwpx_ops.py
+++ b/src/hwpx_mcp_server/hwpx_ops.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """:mod:`python-hwpx` 위에 구축한 고수준 연산 모음."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/legacy_server.py
+++ b/src/hwpx_mcp_server/legacy_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """MCP 서버 진입점(표준 입출력/Streamable HTTP transport 지원)."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/logging_conf.py
+++ b/src/hwpx_mcp_server/logging_conf.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HWPX MCP 서버를 위한 로깅 보조 모듈."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/metadata/tools_meta.py
+++ b/src/hwpx_mcp_server/metadata/tools_meta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Static metadata used for hardened tool responses."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/prompts.py
+++ b/src/hwpx_mcp_server/prompts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """MCP prompts/list, prompts/get에 노출할 프롬프트 정의."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/schema/builder.py
+++ b/src/hwpx_mcp_server/schema/builder.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Helpers for constructing sanitized tool schemas."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/schema/sanitizer.py
+++ b/src/hwpx_mcp_server/schema/sanitizer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Schema sanitizer ensuring draft-07 safe output."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/server.py
+++ b/src/hwpx_mcp_server/server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Stateless HWPX MCP 서버."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/storage.py
+++ b/src/hwpx_mcp_server/storage.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Storage backends for HWPX document operations."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/tools.py
+++ b/src/hwpx_mcp_server/tools.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """MCP 서버가 제공하는 도구 정의."""
 
 from __future__ import annotations

--- a/src/hwpx_mcp_server/upstream.py
+++ b/src/hwpx_mcp_server/upstream.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Thin integration helpers for the upstream ``python-hwpx`` library.
 
 Keep version-sensitive imports and non-obvious upstream calls here so the rest

--- a/src/hwpx_mcp_server/utils/__init__.py
+++ b/src/hwpx_mcp_server/utils/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """유틸리티 헬퍼."""

--- a/src/hwpx_mcp_server/utils/helpers.py
+++ b/src/hwpx_mcp_server/utils/helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary
- relicense this repository to Apache-2.0
- add NOTICE with HWPX trademark / affiliation disclaimer
- align README and release metadata with Apache-2.0
- add SPDX headers to Python sources where applicable

## Sprint Brief
- HWPX 3종 스프린트 — 라이선스 Apache-2.0 통일 + README 개편
- Date: 2026-04-24
- Track: A — license replacement

## Validation
- `python3 -m compileall` on touched Python source/script/example paths
- metadata spot-check for `pyproject.toml` license fields when present
- note: `pytest` was not available in this environment, so full test execution could not run here

## Checklist
- [x] `LICENSE` replaced with Apache-2.0 text
- [x] `NOTICE` added with HWPX format disclaimer
- [x] `pyproject.toml` license/classifier updated (if present)
- [x] SPDX headers inserted in Python sources
- [x] `CHANGELOG.md` updated
- [x] README license badge/section updated
- [ ] CI passes
