### PR TITLE
fix(compat): clamp upstream id generators to signed int32

### DIFF
--- a/src/hwpx_mcp_server/compat.py
+++ b/src/hwpx_mcp_server/compat.py
@@ -35,8 +35,50 @@ def _patch_sub_element_for_lxml_parent() -> None:
     _SUBELEMENT_PATCHED = True
 
 
+_ID_GENERATORS_PATCHED = False
+
+
+def _patch_upstream_id_generators_to_signed_int32() -> None:
+    """Clamp ``hwpx.oxml.document._paragraph_id`` / ``_object_id`` / ``_memo_id``
+    to the signed int32 range.
+
+    Older releases of ``python-hwpx`` mask ``uuid4().int`` with ``0xFFFFFFFF``,
+    which yields values ``>= 2**31`` about half the time. Several downstream
+    HWPX consumers parse the ``id`` attribute as a signed 32-bit integer and
+    misinterpret those values as negative. Once the upstream library masks
+    with ``0x7FFFFFFF`` this patch becomes a no-op; until then it gives
+    hwpx-mcp-server users an in-range guarantee regardless of the installed
+    upstream version.
+    """
+
+    global _ID_GENERATORS_PATCHED
+    if _ID_GENERATORS_PATCHED:
+        return
+
+    try:
+        from hwpx.oxml import document as _hwpx_document
+    except ImportError:
+        return
+
+    from uuid import uuid4
+
+    def _safe_id() -> str:
+        return str(uuid4().int & 0x7FFFFFFF)
+
+    if not hasattr(_hwpx_document, "_paragraph_id"):
+        return
+
+    _hwpx_document._paragraph_id = _safe_id  # type: ignore[attr-defined]
+    if hasattr(_hwpx_document, "_object_id"):
+        _hwpx_document._object_id = _safe_id  # type: ignore[attr-defined]
+    if hasattr(_hwpx_document, "_memo_id"):
+        _hwpx_document._memo_id = _safe_id  # type: ignore[attr-defined]
+    _ID_GENERATORS_PATCHED = True
+
+
 def patch_python_hwpx() -> None:
-    """python-hwpx의 ET 누락/혼합 파서 호환 이슈를 보정합니다."""
+    """python-hwpx의 ET 누락/혼합 파서 호환 이슈와 id 생성 범위를 보정합니다."""
     if not hasattr(builtins, "ET"):
         builtins.ET = _ET
     _patch_sub_element_for_lxml_parent()
+    _patch_upstream_id_generators_to_signed_int32()

--- a/tests/test_compat_id_sanitizer.py
+++ b/tests/test_compat_id_sanitizer.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_patch_state(monkeypatch: pytest.MonkeyPatch):
+    """Reset compat patches so each test exercises the install-time path."""
+
+    from hwpx_mcp_server import compat
+
+    monkeypatch.setattr(compat, "_ID_GENERATORS_PATCHED", False)
+    yield
+
+
+def test_patch_clamps_paragraph_id_to_signed_int32() -> None:
+    from hwpx_mcp_server.compat import _patch_upstream_id_generators_to_signed_int32
+
+    _patch_upstream_id_generators_to_signed_int32()
+
+    from hwpx.oxml import document as _hwpx_document
+
+    samples = [int(_hwpx_document._paragraph_id()) for _ in range(500)]
+    assert max(samples) < 2**31, (
+        f"_paragraph_id produced {max(samples)} (>= 2^31) after compat patch"
+    )
+    assert min(samples) >= 0
+
+
+def test_patch_covers_object_and_memo_ids() -> None:
+    from hwpx_mcp_server.compat import _patch_upstream_id_generators_to_signed_int32
+
+    _patch_upstream_id_generators_to_signed_int32()
+
+    from hwpx.oxml import document as _hwpx_document
+
+    for fn in (_hwpx_document._object_id, _hwpx_document._memo_id):
+        for _ in range(200):
+            value = int(fn())
+            assert 0 <= value < 2**31, (
+                f"{fn.__name__} produced {value} (0x{value:x}); "
+                "must be in [0, 2^31)"
+            )
+
+
+def test_patch_is_idempotent_when_called_twice() -> None:
+    from hwpx_mcp_server.compat import _patch_upstream_id_generators_to_signed_int32
+
+    _patch_upstream_id_generators_to_signed_int32()
+    _patch_upstream_id_generators_to_signed_int32()  # second call is a no-op
+
+    from hwpx.oxml import document as _hwpx_document
+    samples = [int(_hwpx_document._paragraph_id()) for _ in range(200)]
+    assert max(samples) < 2**31
+
+
+def test_paragraphs_added_after_patch_have_in_range_id() -> None:
+    """End-to-end: ``add_paragraph`` issues in-range ids once the compat
+    patch has run.
+
+    The seed paragraph carried over from the upstream ``Skeleton.hwpx``
+    template can still be out of range (filed and patched separately
+    upstream); this test checks only paragraphs that were added by us
+    after the patch is in effect.
+    """
+
+    from hwpx_mcp_server.compat import _patch_upstream_id_generators_to_signed_int32
+
+    _patch_upstream_id_generators_to_signed_int32()
+
+    from hwpx import HwpxDocument
+
+    doc = HwpxDocument.new()
+    seed_paragraph_count = sum(len(s.paragraphs) for s in doc.sections)
+
+    for _ in range(100):
+        doc.add_paragraph("x")
+
+    import io
+    import re
+    import zipfile
+
+    buf = io.BytesIO()
+    doc.save_to_stream(buf)
+    buf.seek(0)
+    section_xml = zipfile.ZipFile(buf).read("Contents/section0.xml").decode()
+
+    paragraph_ids = [
+        int(m.group(1))
+        for m in re.finditer(r'<hp:p[^>]*\sid="(\d+)"', section_xml)
+    ]
+    # Skip the inherited skeleton paragraph(s). We only care about the
+    # ones add_paragraph emitted after the compat patch was active.
+    new_ids = paragraph_ids[seed_paragraph_count:]
+
+    bad = [v for v in new_ids if v >= 2**31]
+    assert not bad, (
+        f"add_paragraph emitted {len(bad)} ids >= 2^31 after compat patch was "
+        f"installed; first offender: {bad[0]:#x}"
+    )
+    assert len(new_ids) >= 100, (
+        f"expected at least 100 new paragraphs, got {len(new_ids)}"
+    )


### PR DESCRIPTION

Closes #63.

## Root cause

`hwpx_mcp_server` is a thin layer over `python-hwpx`. Every editing tool (`add_paragraph`, `insert_paragraph`, `add_table`, `add_memo`, …) ends up calling the three upstream helpers in `hwpx.oxml.document`:

```python
def _paragraph_id() -> str:
    return str(uuid4().int & 0xFFFFFFFF)

def _object_id() -> str:
    return str(uuid4().int & 0xFFFFFFFF)

def _memo_id() -> str:
    return str(uuid4().int & 0xFFFFFFFF)
```

`uuid4().int & 0xFFFFFFFF` is uniformly distributed over the full unsigned 32-bit range, so about 50% of the emitted ids have bit 31 set. Downstream HWPX consumers that interpret `id` as a signed 32-bit integer read those values as negative.

## Fix

`src/hwpx_mcp_server/compat.py` already patches one upstream behaviour at import time (`_patch_sub_element_for_lxml_parent`, added when working around python-hwpx#30). This PR adds a sibling shim with the same shape:

```python
def _patch_upstream_id_generators_to_signed_int32() -> None:
    """Clamp _paragraph_id / _object_id / _memo_id to signed int32 range."""
    global _ID_GENERATORS_PATCHED
    if _ID_GENERATORS_PATCHED:
        return

    try:
        from hwpx.oxml import document as _hwpx_document
    except ImportError:
        return

    from uuid import uuid4

    def _safe_id() -> str:
        return str(uuid4().int & 0x7FFFFFFF)

    if not hasattr(_hwpx_document, "_paragraph_id"):
        return
    _hwpx_document._paragraph_id = _safe_id
    if hasattr(_hwpx_document, "_object_id"):
        _hwpx_document._object_id = _safe_id
    if hasattr(_hwpx_document, "_memo_id"):
        _hwpx_document._memo_id = _safe_id
    _ID_GENERATORS_PATCHED = True
```

…and calls it from `patch_python_hwpx`:

```python
def patch_python_hwpx() -> None:
    """python-hwpx의 ET 누락/혼합 파서 호환 이슈와 id 생성 범위를 보정합니다."""
    if not hasattr(builtins, "ET"):
        builtins.ET = _ET
    _patch_sub_element_for_lxml_parent()
    _patch_upstream_id_generators_to_signed_int32()
```

The patch is idempotent (`_ID_GENERATORS_PATCHED` flag) and is a no-op once the upstream library masks 31 bits itself, at which point this shim can be deleted.

## Regression tests

`tests/test_compat_id_sanitizer.py` (new):

- `test_patch_clamps_paragraph_id_to_signed_int32` — calls the patch, samples 500 ids, asserts `< 2**31`.
- `test_patch_covers_object_and_memo_ids` — same assertion for `_object_id` and `_memo_id`.
- `test_patch_is_idempotent_when_called_twice` — calling the patch twice still yields in-range ids.
- `test_paragraphs_added_after_patch_have_in_range_id` — end-to-end through `HwpxDocument.add_paragraph` with 100 paragraphs; explicitly skips the seed paragraph from `Skeleton.hwpx` (out-of-range there is a separate upstream issue).

```
$ pytest tests/test_compat_id_sanitizer.py -v
4 passed in 0.05s
```

Wider check (sample contract tests still green):

```
$ pytest tests/test_compat_id_sanitizer.py tests/test_contract.py
8 passed in 1.45s
```

## Notes

- This PR is intentionally small and lives in `compat.py` next to the existing python-hwpx workaround.
- Once upstream python-hwpx masks 31 bits in `_paragraph_id`/`_object_id`/`_memo_id`, the new shim becomes a no-op and can be removed.
- The upstream `Skeleton.hwpx` seed paragraph is filed separately against python-hwpx (airmang/python-hwpx#35); this PR does not try to mutate the loaded document, only to clamp newly-generated ids.
