### PR TITLE
[codex] Standardize copy-safe HWPX form filling

### DIFF
--- a/src/hwpx_mcp_server/form_fill.py
+++ b/src/hwpx_mcp_server/form_fill.py
@@ -1,0 +1,620 @@
+"""High-level HWPX form-fill workflow helpers.
+
+The public MCP surface is intentionally two-phase:
+``analyze_form_fill`` is non-mutating and ``apply_form_fill`` owns copy,
+mutation, re-read, and validation evidence.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+import shutil
+import uuid
+import zipfile
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from hwpx.tools.package_validator import validate_package
+
+from .core.content import get_table_data, get_table_map_in_doc, set_cell_text
+from .core.document import open_doc, save_doc
+from .core.formatting import list_styles_in_doc
+from .hwpx_ops import HwpxOps
+from .upstream import HP_NS, validate_document_path
+from .utils.helpers import resolve_path
+
+_FORM_FILL_SCHEMA_VERSION = "hwpx.formfill.v1"
+_DOCX_W_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+_TABLE_DIRECTIONS = {"right", "down"}
+_FORM_FILL_PLANS: dict[str, dict[str, Any]] = {}
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def analyze_form_fill_workflow(
+    *,
+    source_filename: str,
+    input_json: dict[str, Any] | str | None = None,
+    input_json_path: str | None = None,
+    input_docx: str | None = None,
+    destination_filename: str | None = None,
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a non-mutating form-fill analysis and serializable plan."""
+
+    source_path = resolve_path(source_filename)
+    source = Path(source_path)
+    before_hash = sha256_file(source)
+    destination_path = resolve_path(destination_filename) if destination_filename else None
+
+    canonical_input = _load_canonical_input(
+        input_json=input_json,
+        input_json_path=input_json_path,
+        input_docx=input_docx,
+    )
+    doc = open_doc(source_path)
+    table_map = get_table_map_in_doc(doc)
+    styles = list_styles_in_doc(doc)
+    outline = _document_outline(doc)
+    mappings = _build_mapping_analysis(doc, canonical_input)
+    plan_id = f"ff_{uuid.uuid4().hex[:16]}"
+
+    analysis: dict[str, Any] = {
+        "plan_id": plan_id,
+        "schemaVersion": _FORM_FILL_SCHEMA_VERSION,
+        "source": {
+            "filename": source_filename,
+            "path": source_path,
+            "sha256": before_hash,
+            "mtime_ns": source.stat().st_mtime_ns,
+        },
+        "destination": {
+            "filename": destination_filename,
+            "path": destination_path,
+            "required": bool(destination_filename),
+            "will_be_created_by": "apply_form_fill",
+        },
+        "canonicalInput": canonical_input,
+        "document": {
+            "info": {
+                "sections": len(getattr(doc, "sections", [])),
+                "paragraphs": len(getattr(doc, "paragraphs", [])),
+                "tables": len(table_map.get("tables", [])),
+            },
+            "outline": outline,
+            "tables": table_map.get("tables", []),
+            "styles": styles,
+            "styleCount": len(styles),
+        },
+        "mappings": mappings,
+        "unresolved_count": len(mappings["unresolved"]),
+        "resolved_count": len(mappings["resolved"]),
+        "mutated": False,
+        "next_tool": "apply_form_fill",
+        "options": options or {},
+    }
+    _FORM_FILL_PLANS[plan_id] = copy.deepcopy(analysis)
+    after_hash = sha256_file(source)
+    analysis["source"]["unchanged_after_analysis"] = after_hash == before_hash
+    return analysis
+
+
+def apply_form_fill_workflow(
+    *,
+    plan_id: str | None = None,
+    analysis: dict[str, Any] | None = None,
+    source_filename: str | None = None,
+    destination_filename: str | None = None,
+    canonical_input: dict[str, Any] | str | None = None,
+    confirm: bool = True,
+) -> dict[str, Any]:
+    """Apply a resolved form-fill plan to a copied destination and validate it."""
+
+    if not confirm:
+        raise ValueError("confirm must be true to apply form-fill mutations")
+
+    plan = _resolve_analysis(plan_id=plan_id, analysis=analysis)
+    if canonical_input is not None:
+        plan["canonicalInput"] = _load_canonical_input(input_json=canonical_input)
+        doc_for_mapping = open_doc(_source_path_from_plan(plan, source_filename))
+        plan["mappings"] = _build_mapping_analysis(doc_for_mapping, plan["canonicalInput"])
+
+    source_path = _source_path_from_plan(plan, source_filename)
+    destination_path = _destination_path_from_plan(plan, destination_filename)
+    if Path(source_path).resolve(strict=False) == Path(destination_path).resolve(strict=False):
+        raise ValueError("apply_form_fill refuses source-in-place edits; destination_filename must differ from source")
+
+    unresolved = list(plan.get("mappings", {}).get("unresolved", []))
+    if unresolved:
+        return {
+            "handoff_status": "blocked",
+            "reason": "unresolved mappings remain",
+            "unresolved": unresolved,
+            "applied": [],
+            "source": {"path": source_path, "sha256": sha256_file(source_path)},
+            "destination": {"path": destination_path},
+        }
+
+    source = Path(source_path)
+    destination = Path(destination_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    source_before_hash = sha256_file(source)
+    source_before_mtime = source.stat().st_mtime_ns
+    shutil.copy2(source, destination)
+    copied_hash = sha256_file(destination)
+
+    doc = open_doc(str(destination))
+    applied: list[dict[str, Any]] = []
+    for mapping in plan.get("mappings", {}).get("resolved", []):
+        if mapping.get("kind") == "cell":
+            table_index = int(mapping["table_index"])
+            row = int(mapping["row"])
+            col = int(mapping["col"])
+            before_style = _cell_style_snapshot(doc, table_index, row, col)
+            before_text = _cell_text(doc, table_index, row, col)
+            set_cell_text(doc, table_index, row, col, str(mapping.get("value", "")))
+            after_style = _cell_style_snapshot(doc, table_index, row, col)
+            applied.append(
+                {
+                    **mapping,
+                    "before_text": before_text,
+                    "after_text": str(mapping.get("value", "")),
+                    "style_before": before_style,
+                    "style_after": after_style,
+                    "style_preserved": before_style == after_style,
+                }
+            )
+        elif mapping.get("kind") == "placeholder":
+            token = str(mapping["token"])
+            value = str(mapping.get("value", ""))
+            replacements = _replace_placeholder(doc, token, value)
+            applied.append(
+                {
+                    **mapping,
+                    "replaced_count": sum(item["replace_count"] for item in replacements),
+                    "replacements": replacements,
+                    "style_preserved": all(item["style_preserved"] for item in replacements),
+                }
+            )
+
+    save_doc(doc, str(destination))
+    reread_doc = open_doc(str(destination))
+    touched = _reread_touched(reread_doc, applied)
+    validation = _runtime_validation(str(destination))
+    source_after_hash = sha256_file(source)
+    source_after_mtime = source.stat().st_mtime_ns
+    output_hash = sha256_file(destination)
+    ok = bool(validation["validate_structure"]["ok"] and validation["validate_package"]["ok"] and validation["validate_document"]["ok"])
+
+    return {
+        "handoff_status": "ready" if ok else "blocked",
+        "plan_id": plan.get("plan_id"),
+        "source": {
+            "path": str(source),
+            "sha256_before": source_before_hash,
+            "sha256_after": source_after_hash,
+            "mtime_ns_before": source_before_mtime,
+            "mtime_ns_after": source_after_mtime,
+            "preserved": source_before_hash == source_after_hash and source_before_mtime == source_after_mtime,
+        },
+        "destination": {
+            "path": str(destination),
+            "sha256_after_copy": copied_hash,
+            "sha256_after_apply": output_hash,
+            "changed": copied_hash != output_hash,
+        },
+        "lineage_id": _lineage_id(source_before_hash, str(destination)),
+        "applied": applied,
+        "unresolved": [],
+        "touched": touched,
+        "validation": validation,
+        "persisted": True,
+    }
+
+
+def _load_canonical_input(
+    *,
+    input_json: dict[str, Any] | str | None = None,
+    input_json_path: str | None = None,
+    input_docx: str | None = None,
+) -> dict[str, Any]:
+    provided = [value is not None for value in (input_json, input_json_path, input_docx)].count(True)
+    if provided != 1:
+        raise ValueError("provide exactly one of input_json, input_json_path, or input_docx")
+
+    if input_json_path is not None:
+        payload = json.loads(Path(resolve_path(input_json_path)).read_text(encoding="utf-8"))
+    elif input_docx is not None:
+        payload = _canonical_input_from_docx(resolve_path(input_docx))
+    elif isinstance(input_json, str):
+        stripped = input_json.strip()
+        possible_path = Path(stripped).expanduser()
+        if possible_path.suffix.lower() == ".json" and possible_path.exists():
+            payload = json.loads(possible_path.read_text(encoding="utf-8"))
+        else:
+            payload = json.loads(stripped)
+    elif isinstance(input_json, dict):
+        payload = copy.deepcopy(input_json)
+    else:  # pragma: no cover - defensive, provided count catches this
+        raise ValueError("input_json must be an object, JSON string, or JSON path")
+
+    return _normalize_canonical_input(payload)
+
+
+def _normalize_canonical_input(payload: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("canonical input must be a JSON object")
+    normalized = copy.deepcopy(payload)
+    normalized.setdefault("schemaVersion", _FORM_FILL_SCHEMA_VERSION)
+    if normalized["schemaVersion"] != _FORM_FILL_SCHEMA_VERSION:
+        raise ValueError(f"unsupported form-fill schemaVersion: {normalized['schemaVersion']}")
+    normalized.setdefault("source", {"type": "structured"})
+    fields = normalized.setdefault("fields", [])
+    if not isinstance(fields, list):
+        raise ValueError("fields must be a list")
+    for index, field in enumerate(fields):
+        if not isinstance(field, dict):
+            raise ValueError(f"fields[{index}] must be an object")
+        label = str(field.get("label") or field.get("key") or "").strip()
+        if not label:
+            raise ValueError(f"fields[{index}] requires label or key")
+        field.setdefault("key", label)
+        field.setdefault("label", label)
+        field.setdefault("value", "")
+        field.setdefault("stylePolicy", "preserve-target")
+        field.setdefault("target", {"kind": "label-path", "path": f"{label} > right"})
+    paragraphs = normalized.setdefault("paragraphs", [])
+    if not isinstance(paragraphs, list):
+        raise ValueError("paragraphs must be a list")
+    return normalized
+
+
+def _canonical_input_from_docx(path: str) -> dict[str, Any]:
+    docx_path = Path(path)
+    if docx_path.suffix.lower() != ".docx":
+        raise ValueError("input_docx must point to a .docx file")
+    if not zipfile.is_zipfile(docx_path):
+        raise ValueError("input_docx is not a valid DOCX zip package; provide input_json instead")
+    try:
+        with zipfile.ZipFile(docx_path) as archive:
+            xml = archive.read("word/document.xml")
+    except KeyError as exc:
+        raise ValueError("input_docx does not contain word/document.xml; provide input_json instead") from exc
+
+    root = ET.fromstring(xml)
+    body = root.find(f"{_DOCX_W_NS}body")
+    if body is None:
+        raise ValueError("input_docx does not contain a Word document body; provide input_json instead")
+
+    fields: list[dict[str, Any]] = []
+    for child in body:
+        if child.tag == f"{_DOCX_W_NS}tbl":
+            for row in child.iter(f"{_DOCX_W_NS}tr"):
+                cells = [_element_text(cell).strip() for cell in row.findall(f"{_DOCX_W_NS}tc")]
+                cells = [cell for cell in cells if cell]
+                if len(cells) >= 2:
+                    label, value = cells[0], cells[1]
+                    fields.append(_field_from_label_value(label, value, source="docx-table"))
+        elif child.tag == f"{_DOCX_W_NS}p":
+            text = _element_text(child).strip()
+            if not text or "=" not in text and ":" not in text:
+                continue
+            label, value = re.split(r"[:=]", text, maxsplit=1)
+            if label.strip() and value.strip():
+                fields.append(_field_from_label_value(label.strip(), value.strip(), source="docx-paragraph"))
+    if not fields:
+        raise ValueError("input_docx did not contain key/value fields; provide canonical input_json")
+    return {
+        "schemaVersion": _FORM_FILL_SCHEMA_VERSION,
+        "source": {"type": "docx", "path": path, "sha256": sha256_file(path)},
+        "fields": fields,
+        "paragraphs": [],
+    }
+
+
+def _field_from_label_value(label: str, value: str, *, source: str) -> dict[str, Any]:
+    return {
+        "key": _slug_key(label),
+        "label": label,
+        "value": value,
+        "target": {"kind": "label-path", "path": f"{label} > right"},
+        "stylePolicy": "preserve-target",
+        "provenance": {"source": source},
+    }
+
+
+def _element_text(element: ET.Element) -> str:
+    return "".join(node.text or "" for node in element.iter(f"{_DOCX_W_NS}t"))
+
+
+def _slug_key(label: str) -> str:
+    slug = re.sub(r"\W+", "_", label.strip(), flags=re.UNICODE).strip("_")
+    return slug or "field"
+
+
+def _document_outline(doc: Any) -> list[dict[str, Any]]:
+    outline = []
+    for index, para in enumerate(getattr(doc, "paragraphs", [])):
+        text = (getattr(para, "text", None) or "").strip()
+        if not text:
+            continue
+        level = 1 if len(text) < 80 else 0
+        if text.startswith("#"):
+            level = min(6, len(text) - len(text.lstrip("#")))
+        if level:
+            outline.append({"level": level, "text": text, "paragraph_index": index})
+    return outline
+
+
+def _build_mapping_analysis(doc: Any, canonical_input: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    resolved: list[dict[str, Any]] = []
+    unresolved: list[dict[str, Any]] = []
+    for field in _iter_fill_items(canonical_input):
+        target = field.get("target") or {}
+        kind = target.get("kind", "label-path")
+        if kind in {"cell", "coordinate"} or {"table_index", "row", "col"}.issubset(target):
+            resolved.append(_resolved_cell_mapping(field, target, method="explicit-coordinate"))
+            continue
+        if kind == "label-path":
+            label, direction = _label_and_direction(field, target)
+            matches = doc.find_cell_by_label(label, direction=direction).get("matches", [])
+            if len(matches) == 1:
+                match = matches[0]
+                cell = match["target_cell"]
+                resolved.append(
+                    {
+                        "kind": "cell",
+                        "key": field.get("key"),
+                        "label": label,
+                        "value": str(field.get("value", "")),
+                        "table_index": match["table_index"],
+                        "row": cell["row"],
+                        "col": cell["col"],
+                        "current_text": cell.get("text", ""),
+                        "stylePolicy": field.get("stylePolicy", "preserve-target"),
+                        "confidence": "high",
+                        "method": "label-path",
+                    }
+                )
+            else:
+                unresolved.append(
+                    {
+                        "kind": "cell",
+                        "key": field.get("key"),
+                        "label": label,
+                        "value": str(field.get("value", "")),
+                        "reason": "label not found" if not matches else "ambiguous label",
+                        "candidates": matches,
+                        "candidate_count": len(matches),
+                        "next_action": "provide explicit table_index/row/col target",
+                    }
+                )
+            continue
+        if kind == "placeholder":
+            token = target.get("token")
+            if not token:
+                unresolved.append({"kind": "placeholder", "key": field.get("key"), "reason": "missing token"})
+            else:
+                resolved.append(
+                    {
+                        "kind": "placeholder",
+                        "key": field.get("key"),
+                        "token": str(token),
+                        "value": str(field.get("value", "")),
+                        "stylePolicy": field.get("stylePolicy", "preserve-placeholder"),
+                        "method": "placeholder",
+                    }
+                )
+            continue
+        unresolved.append({"kind": kind, "key": field.get("key"), "reason": f"unsupported target kind: {kind}"})
+    return {"resolved": resolved, "unresolved": unresolved}
+
+
+def _iter_fill_items(canonical_input: dict[str, Any]) -> list[dict[str, Any]]:
+    items = list(canonical_input.get("fields", []))
+    for paragraph in canonical_input.get("paragraphs", []):
+        if isinstance(paragraph, dict):
+            items.append(
+                {
+                    "key": paragraph.get("key"),
+                    "label": paragraph.get("label") or paragraph.get("key"),
+                    "value": paragraph.get("value", paragraph.get("text", "")),
+                    "target": paragraph.get("target"),
+                    "stylePolicy": paragraph.get("stylePolicy", "preserve-placeholder"),
+                }
+            )
+    return items
+
+
+def _resolved_cell_mapping(field: dict[str, Any], target: dict[str, Any], *, method: str) -> dict[str, Any]:
+    return {
+        "kind": "cell",
+        "key": field.get("key"),
+        "label": field.get("label"),
+        "value": str(field.get("value", "")),
+        "table_index": int(target.get("table_index", target.get("tableIndex", 0))),
+        "row": int(target["row"]),
+        "col": int(target["col"]),
+        "stylePolicy": field.get("stylePolicy", "preserve-target"),
+        "confidence": "explicit",
+        "method": method,
+    }
+
+
+def _label_and_direction(field: dict[str, Any], target: dict[str, Any]) -> tuple[str, str]:
+    path = str(target.get("path") or f"{field.get('label')} > right")
+    parts = [part.strip() for part in path.split(">") if part.strip()]
+    label = parts[0] if parts else str(field.get("label") or field.get("key"))
+    direction = parts[1].casefold() if len(parts) > 1 else "right"
+    if direction not in _TABLE_DIRECTIONS:
+        raise ValueError("label-path target currently supports right or down as the first direction")
+    return label, direction
+
+
+def _resolve_analysis(*, plan_id: str | None, analysis: dict[str, Any] | None) -> dict[str, Any]:
+    if analysis is not None:
+        return copy.deepcopy(analysis)
+    if plan_id is None:
+        raise ValueError("provide plan_id or analysis")
+    try:
+        return copy.deepcopy(_FORM_FILL_PLANS[plan_id])
+    except KeyError as exc:
+        raise ValueError(f"unknown form-fill plan_id: {plan_id}") from exc
+
+
+def _source_path_from_plan(plan: dict[str, Any], override: str | None) -> str:
+    if override:
+        return resolve_path(override)
+    source = plan.get("source") or {}
+    path = source.get("path") or source.get("filename")
+    if not path:
+        raise ValueError("source_filename is required")
+    return resolve_path(str(path))
+
+
+def _destination_path_from_plan(plan: dict[str, Any], override: str | None) -> str:
+    if override:
+        return resolve_path(override)
+    destination = plan.get("destination") or {}
+    path = destination.get("path") or destination.get("filename")
+    if not path:
+        raise ValueError("destination_filename is required")
+    return resolve_path(str(path))
+
+
+def _cell_style_snapshot(doc: Any, table_index: int, row: int, col: int) -> dict[str, Any]:
+    cell = _cell(doc, table_index, row, col)
+    paragraph = cell.paragraphs[0] if getattr(cell, "paragraphs", []) else None
+    return _paragraph_style_snapshot(paragraph)
+
+
+def _paragraph_style_snapshot(paragraph: Any) -> dict[str, Any]:
+    run = paragraph.runs[0] if paragraph is not None and getattr(paragraph, "runs", []) else None
+    return {
+        "para_pr_id_ref": getattr(paragraph, "para_pr_id_ref", None),
+        "style_id_ref": getattr(paragraph, "style_id_ref", None),
+        "char_pr_id_ref": getattr(paragraph, "char_pr_id_ref", None),
+        "run_char_pr_id_ref": getattr(run, "char_pr_id_ref", None),
+    }
+
+
+def _cell_text(doc: Any, table_index: int, row: int, col: int) -> str:
+    return _cell(doc, table_index, row, col).text or ""
+
+
+def _cell(doc: Any, table_index: int, row: int, col: int) -> Any:
+    tables = []
+    for paragraph in doc.paragraphs:
+        tables.extend(getattr(paragraph, "tables", []))
+    return tables[table_index].rows[row].cells[col]
+
+
+def _replace_placeholder(doc: Any, token: str, value: str) -> list[dict[str, Any]]:
+    replacements: list[dict[str, Any]] = []
+    for paragraph_index, paragraph in enumerate(doc.paragraphs):
+        before_text = paragraph.text or ""
+        if token not in before_text:
+            continue
+        before_style = _paragraph_style_snapshot(paragraph)
+        replace_count = 0
+        for run in paragraph.runs:
+            text = run.text or ""
+            if token in text:
+                replace_count += text.count(token)
+                run.text = text.replace(token, value)
+        after_style = _paragraph_style_snapshot(paragraph)
+        replacements.append(
+            {
+                "paragraph_index": paragraph_index,
+                "before_text": before_text,
+                "after_text": paragraph.text or "",
+                "replace_count": replace_count,
+                "style_before": before_style,
+                "style_after": after_style,
+                "style_preserved": before_style == after_style,
+            }
+        )
+    return replacements
+
+
+def _reread_touched(doc: Any, applied: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    touched = []
+    for item in applied:
+        if item.get("kind") == "cell":
+            table_index = int(item["table_index"])
+            row = int(item["row"])
+            col = int(item["col"])
+            data = get_table_data(doc, table_index)
+            touched.append(
+                {
+                    "kind": "cell",
+                    "table_index": table_index,
+                    "row": row,
+                    "col": col,
+                    "text": data["data"][row][col],
+                    "style": _cell_style_snapshot(doc, table_index, row, col),
+                }
+            )
+        elif item.get("kind") == "placeholder":
+            for replacement in item.get("replacements", []):
+                paragraph_index = int(replacement["paragraph_index"])
+                paragraph = doc.paragraphs[paragraph_index]
+                touched.append(
+                    {
+                        "kind": "placeholder",
+                        "paragraph_index": paragraph_index,
+                        "text": paragraph.text or "",
+                        "style": _paragraph_style_snapshot(paragraph),
+                    }
+                )
+    return touched
+
+
+def _runtime_validation(path: str) -> dict[str, Any]:
+    ops = HwpxOps(auto_backup=False)
+    structure = ops.validate_structure(path)
+    package_report = validate_package(path)
+    document_report = validate_document_path(path)
+    return {
+        "validate_structure": structure,
+        "validate_package": _package_report(package_report),
+        "validate_document": _document_report(document_report),
+    }
+
+
+def _package_report(report: Any) -> dict[str, Any]:
+    return {
+        "ok": bool(getattr(report, "ok", False)),
+        "checked_parts": list(getattr(report, "checked_parts", ())),
+        "issues": [_issue_payload(issue) for issue in getattr(report, "issues", ())],
+    }
+
+
+def _document_report(report: Any) -> dict[str, Any]:
+    return {
+        "ok": bool(getattr(report, "ok", False)),
+        "validated_parts": list(getattr(report, "validated_parts", ())),
+        "issues": [_issue_payload(issue) for issue in getattr(report, "issues", ())],
+    }
+
+
+def _issue_payload(issue: Any) -> dict[str, Any]:
+    return {
+        "part": getattr(issue, "part_name", None),
+        "message": getattr(issue, "message", str(issue)),
+        "level": getattr(issue, "level", "error"),
+    }
+
+
+def _lineage_id(source_hash: str, destination: str) -> str:
+    return hashlib.sha256(f"{source_hash}:{destination}".encode("utf-8")).hexdigest()[:16]

--- a/src/hwpx_mcp_server/server.py
+++ b/src/hwpx_mcp_server/server.py
@@ -44,6 +44,7 @@ from .core.content import (
 from .core.document import create_blank, open_doc, save_doc
 from .core.formatting import create_style_in_doc, format_text_range, list_styles_in_doc
 from .core.search import batch_replace_in_doc, find_in_doc, replace_in_doc
+from .form_fill import analyze_form_fill_workflow, apply_form_fill_workflow
 from .hwpx_ops import HwpxOps
 from .upstream import HP_NS, create_text_extractor, open_document
 from .utils.helpers import default_max_chars, resolve_path, truncate_response
@@ -1147,6 +1148,46 @@ def copy_document(source_filename: str, destination_filename: str = None) -> dic
         destination = resolve_path(destination_filename)
     dest = copy_document_file(source, destination)
     return {"source": source_filename, "destination": os.path.basename(dest)}
+
+
+@mcp.tool()
+def analyze_form_fill(
+    source_filename: str,
+    input_json: dict = None,
+    input_json_path: str = None,
+    input_docx: str = None,
+    destination_filename: str = None,
+    options: dict = None,
+) -> dict:
+    """HWPX 양식 채움 계획을 분석합니다. 파일 복사/채움 변경은 하지 않습니다."""
+    return analyze_form_fill_workflow(
+        source_filename=source_filename,
+        input_json=input_json,
+        input_json_path=input_json_path,
+        input_docx=input_docx,
+        destination_filename=destination_filename,
+        options=options,
+    )
+
+
+@mcp.tool()
+def apply_form_fill(
+    plan_id: str = None,
+    analysis: dict = None,
+    source_filename: str = None,
+    destination_filename: str = None,
+    canonical_input: dict = None,
+    confirm: bool = True,
+) -> dict:
+    """분석된 HWPX 양식 채움 계획을 복사본에만 적용하고 구조/패키지를 검증합니다."""
+    return apply_form_fill_workflow(
+        plan_id=plan_id,
+        analysis=analysis,
+        source_filename=source_filename,
+        destination_filename=destination_filename,
+        canonical_input=canonical_input,
+        confirm=confirm,
+    )
 
 
 if _advanced_enabled():

--- a/tests/test_form_fill_mcp_e2e.py
+++ b/tests/test_form_fill_mcp_e2e.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+import pytest
+
+import hwpx_mcp_server.server as server
+from hwpx.tools.package_validator import validate_package
+from hwpx.tools.validator import validate_document
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _build_template(path: Path, *, duplicate: bool = False) -> None:
+    server.create_document(str(path))
+    server.add_heading(str(path), "교과협의회 회의록", level=1)
+    server.add_table(
+        str(path),
+        3,
+        2,
+        [["일시", ""], ["장소", ""], ["참석자", ""]],
+    )
+    if duplicate:
+        server.add_heading(str(path), "후속 회의", level=2)
+        server.add_table(str(path), 1, 2, [["일시", ""]])
+
+
+def _structured_input() -> dict:
+    return {
+        "schemaVersion": "hwpx.formfill.v1",
+        "source": {"type": "structured"},
+        "fields": [
+            {"key": "meeting.date", "label": "일시", "value": "2026-05-05 10:00"},
+            {"key": "meeting.place", "label": "장소", "value": "AI실"},
+            {"key": "meeting.attendees", "label": "참석자", "value": "김교사, 이교사"},
+        ],
+    }
+
+
+def _write_minimal_docx(path: Path, rows: list[tuple[str, str]]) -> None:
+    row_xml = []
+    for label, value in rows:
+        row_xml.append(
+            "<w:tr>"
+            f"<w:tc><w:p><w:r><w:t>{escape(label)}</w:t></w:r></w:p></w:tc>"
+            f"<w:tc><w:p><w:r><w:t>{escape(value)}</w:t></w:r></w:p></w:tc>"
+            "</w:tr>"
+        )
+    document_xml = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main'>"
+        "<w:body><w:tbl>" + "".join(row_xml) + "</w:tbl></w:body></w:document>"
+    )
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types xmlns='http://schemas.openxmlformats.org/package/2006/content-types'/>")
+        archive.writestr("word/document.xml", document_xml)
+
+
+def test_form_fill_tools_are_exposed() -> None:
+    names = set(server.mcp._tool_manager._tools.keys())
+
+    assert {"analyze_form_fill", "apply_form_fill"}.issubset(names)
+
+
+def test_analyze_form_fill_is_non_mutating_and_apply_preserves_source(tmp_path: Path) -> None:
+    source = tmp_path / "meeting-template.hwpx"
+    destination = tmp_path / "meeting-filled.hwpx"
+    _build_template(source)
+    source_hash_before = _sha256(source)
+    source_mtime_before = source.stat().st_mtime_ns
+
+    analysis = server.analyze_form_fill(
+        str(source),
+        input_json=_structured_input(),
+        destination_filename=str(destination),
+    )
+
+    assert analysis["mutated"] is False
+    assert analysis["source"]["unchanged_after_analysis"] is True
+    assert analysis["resolved_count"] == 3
+    assert analysis["unresolved_count"] == 0
+    assert not destination.exists(), "analysis must not copy or fill the destination"
+    assert _sha256(source) == source_hash_before
+
+    result = server.apply_form_fill(analysis=analysis, confirm=True)
+
+    assert result["handoff_status"] == "ready"
+    assert result["source"]["preserved"] is True
+    assert result["source"]["sha256_before"] == source_hash_before
+    assert result["source"]["mtime_ns_before"] == source_mtime_before
+    assert destination.exists()
+    assert result["destination"]["changed"] is True
+    assert result["validation"]["validate_structure"]["ok"] is True
+    assert result["validation"]["validate_package"]["ok"] is True
+    assert result["validation"]["validate_document"]["ok"] is True
+    assert validate_package(destination).ok
+    assert validate_document(destination).ok
+    assert _sha256(source) == source_hash_before
+    assert source.stat().st_mtime_ns == source_mtime_before
+
+    filled = server.get_table_text(str(destination), 0)["data"]
+    assert filled == [
+        ["일시", "2026-05-05 10:00"],
+        ["장소", "AI실"],
+        ["참석자", "김교사, 이교사"],
+    ]
+    assert all(item["style_preserved"] for item in result["applied"])
+    assert {item["text"] for item in result["touched"]} >= {"2026-05-05 10:00", "AI실", "김교사, 이교사"}
+
+
+def test_duplicate_label_analysis_blocks_apply_until_explicit_coordinate(tmp_path: Path) -> None:
+    source = tmp_path / "duplicate-template.hwpx"
+    destination = tmp_path / "duplicate-filled.hwpx"
+    _build_template(source, duplicate=True)
+
+    ambiguous = server.analyze_form_fill(
+        str(source),
+        input_json={
+            "schemaVersion": "hwpx.formfill.v1",
+            "fields": [{"key": "date", "label": "일시", "value": "2026-05-05"}],
+        },
+        destination_filename=str(destination),
+    )
+
+    assert ambiguous["resolved_count"] == 0
+    assert ambiguous["unresolved_count"] == 1
+    assert ambiguous["mappings"]["unresolved"][0]["reason"] == "ambiguous label"
+    assert ambiguous["mappings"]["unresolved"][0]["candidate_count"] == 2
+
+    blocked = server.apply_form_fill(analysis=ambiguous, confirm=True)
+    assert blocked["handoff_status"] == "blocked"
+    assert not destination.exists()
+
+    explicit = server.analyze_form_fill(
+        str(source),
+        input_json={
+            "schemaVersion": "hwpx.formfill.v1",
+            "fields": [
+                {
+                    "key": "date",
+                    "label": "일시",
+                    "value": "2026-05-05",
+                    "target": {"kind": "cell", "table_index": 1, "row": 0, "col": 1},
+                }
+            ],
+        },
+        destination_filename=str(destination),
+    )
+    result = server.apply_form_fill(analysis=explicit, confirm=True)
+
+    assert result["handoff_status"] == "ready"
+    assert server.get_table_text(str(destination), 1)["data"][0][1] == "2026-05-05"
+    assert server.get_table_text(str(destination), 0)["data"][0][1] == ""
+
+
+def test_docx_origin_normalizes_to_same_fill_result_as_structured_json(tmp_path: Path) -> None:
+    source = tmp_path / "docx-template.hwpx"
+    from_json = tmp_path / "from-json.hwpx"
+    from_docx = tmp_path / "from-docx.hwpx"
+    docx = tmp_path / "meeting-input.docx"
+    _build_template(source)
+    _write_minimal_docx(
+        docx,
+        [("일시", "2026-05-05 10:00"), ("장소", "AI실"), ("참석자", "김교사, 이교사")],
+    )
+
+    json_analysis = server.analyze_form_fill(
+        str(source),
+        input_json=_structured_input(),
+        destination_filename=str(from_json),
+    )
+    docx_analysis = server.analyze_form_fill(
+        str(source),
+        input_docx=str(docx),
+        destination_filename=str(from_docx),
+    )
+
+    assert docx_analysis["canonicalInput"]["source"]["type"] == "docx"
+    assert docx_analysis["resolved_count"] == json_analysis["resolved_count"] == 3
+
+    json_result = server.apply_form_fill(analysis=json_analysis, confirm=True)
+    docx_result = server.apply_form_fill(analysis=docx_analysis, confirm=True)
+
+    assert json_result["handoff_status"] == "ready"
+    assert docx_result["handoff_status"] == "ready"
+    assert server.get_table_text(str(from_json), 0)["data"] == server.get_table_text(str(from_docx), 0)["data"]
+
+
+def test_paragraph_placeholder_fill_preserves_paragraph_style(tmp_path: Path) -> None:
+    source = tmp_path / "placeholder-template.hwpx"
+    destination = tmp_path / "placeholder-filled.hwpx"
+    _build_template(source)
+    placeholder_index = server.add_paragraph(str(source), "안건: {{agenda_1}}")["paragraph_index"]
+    source_hash_before = _sha256(source)
+
+    analysis = server.analyze_form_fill(
+        str(source),
+        input_json={
+            "schemaVersion": "hwpx.formfill.v1",
+            "source": {"type": "structured"},
+            "paragraphs": [
+                {
+                    "key": "agenda.1",
+                    "text": "AI 활용 수업 설계",
+                    "target": {"kind": "placeholder", "token": "{{agenda_1}}"},
+                    "stylePolicy": "preserve-placeholder",
+                }
+            ],
+        },
+        destination_filename=str(destination),
+    )
+    result = server.apply_form_fill(analysis=analysis, confirm=True)
+
+    assert result["handoff_status"] == "ready"
+    assert result["source"]["preserved"] is True
+    assert _sha256(source) == source_hash_before
+    assert result["applied"][0]["replaced_count"] == 1
+    assert result["applied"][0]["style_preserved"] is True
+    assert result["touched"][0]["kind"] == "placeholder"
+    assert result["touched"][0]["paragraph_index"] == placeholder_index
+    assert server.get_paragraph_text(str(destination), placeholder_index)["text"] == "안건: AI 활용 수업 설계"
+
+
+def test_existing_sample_hwpx_safe_coordinate_fill_smoke(tmp_path: Path) -> None:
+    source = Path("tests/sample.hwpx")
+    destination = tmp_path / "sample-filled.hwpx"
+    source_hash_before = _sha256(source)
+    source_mtime_before = source.stat().st_mtime_ns
+
+    analysis = server.analyze_form_fill(
+        str(source),
+        input_json={
+            "schemaVersion": "hwpx.formfill.v1",
+            "source": {"type": "structured"},
+            "fields": [
+                {
+                    "key": "sample.a2",
+                    "label": "A2",
+                    "value": "샘플 회귀 검증",
+                    "target": {"kind": "cell", "table_index": 0, "row": 0, "col": 1},
+                }
+            ],
+        },
+        destination_filename=str(destination),
+    )
+    result = server.apply_form_fill(analysis=analysis, confirm=True)
+
+    assert result["handoff_status"] == "ready"
+    assert result["source"]["preserved"] is True
+    assert _sha256(source) == source_hash_before
+    assert source.stat().st_mtime_ns == source_mtime_before
+    assert result["validation"]["validate_structure"]["ok"] is True
+    assert validate_package(destination).ok
+    assert validate_document(destination).ok
+    assert server.get_table_text(str(destination), 0)["data"][0][1] == "샘플 회귀 검증"
+
+
+def test_invalid_docx_returns_structured_recovery_hint(tmp_path: Path) -> None:
+    source = tmp_path / "template.hwpx"
+    bad_docx = tmp_path / "bad.docx"
+    _build_template(source)
+    bad_docx.write_text("not a zip", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="provide input_json"):
+        server.analyze_form_fill(str(source), input_docx=str(bad_docx))


### PR DESCRIPTION
## Summary

Adds a two-phase MCP form-fill workflow for HWPX templates:

- `analyze_form_fill` performs non-mutating template inspection, DOCX/structured-input normalization, and mapping analysis.
- `apply_form_fill` copies the source to a destination, mutates only the copied output, re-reads touched regions, and returns validation evidence.
- Adds E2E regressions for original preservation, duplicate-label ambiguity, explicit coordinates, paragraph placeholders, DOCX-origin equivalence, and an existing sample HWPX smoke path.

## Why

Agents previously had to stitch together low-level copy/read/edit/validate calls themselves. This made copy-first behavior, ambiguous table labels, DOCX-origin inputs, style preservation evidence, and final validation easy to miss. The new workflow provides a standard copy-safe interface while continuing to delegate HWPX table/style/package semantics to existing python-hwpx-backed helpers.

## Validation

- `pytest tests/test_form_fill_mcp_e2e.py -q` — 7 passed
- `pytest tests/test_mcp_end_to_end.py tests/test_tool_schemas.py tests/test_file_edit_e2e.py tests/test_form_fill_mcp_e2e.py -q` — 23 passed
- `HWPX_MCP_ADVANCED=1 pytest tests/test_mcp_end_to_end.py tests/test_form_fill_mcp_e2e.py -q` — 12 passed
- `python -m compileall -q src tests/test_form_fill_mcp_e2e.py`
- `pytest -q` — 65 passed

## Notes

- No `python-hwpx` source changes were included; the existing local sibling worktree was dirty, and the MCP implementation passed the required gates using current public/wrapper APIs.
- This is opened as a draft for maintainer review of the new public MCP tool surface.