### PR TITLE
[codex] Expose HWPX proposal quality MCP tools

### DIFF
--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -256,3 +256,19 @@ Layer ownership:
 - `python-hwpx` stays the upstream engine for HWPX/package behavior.
 - `hwpx-mcp-server` exposes the stable MCP product surface through `src/hwpx_mcp_server/server.py`.
 - Skills and workflow examples orchestrate those tools; they do not replace core editing logic.
+
+## Agent-first proposal document generation
+
+When `python-hwpx` exposes `hwpx.presets`, the MCP server can generate and inspect proposal/planning documents with high-level tools:
+
+- `create_proposal_document(filename, proposal_spec, style_preset="clean_korean_proposal")`
+- `inspect_document_quality(filename, rubric="proposal")`
+
+Recommended flow:
+
+1. Convert the user's natural-language request into `proposal_spec` JSON.
+2. Call `create_proposal_document` to write the HWPX.
+3. Call `inspect_document_quality` to check validation, required sections, tables, asset weight, rubric scores, and the v2 `sample_match` proxy dimensions.
+4. Revise `proposal_spec` if average rubric score is below 4.0, `sample_match.pass` is false, or a required section is missing.
+
+This path intentionally benchmarks DOCX-style document principles without implementing a DOCX converter, GUI, model tuning, renderer, or pixel-diff gate. `visual_review_required=True` means rendered parity is not claimed.

--- a/src/hwpx_mcp_server.egg-info/PKG-INFO
+++ b/src/hwpx_mcp_server.egg-info/PKG-INFO
@@ -1,7 +1,7 @@
 Metadata-Version: 2.4
 Name: hwpx-mcp-server
 Version: 2.2.5
-Summary: Model Context Protocol server for local HWPX document automation.
+Summary: MCP server for reading, editing, inspecting, and validating local HWPX documents with AI agents.
 Author: Kohkyuhyun
 License: MIT License
         
@@ -25,6 +25,9 @@ License: MIT License
         OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
         SOFTWARE.
         
+Project-URL: Homepage, https://github.com/airmang/hwpx-mcp-server
+Project-URL: Issues, https://github.com/airmang/hwpx-mcp-server/issues
+Keywords: hwpx,hancom,mcp,model-context-protocol,document-automation,ai-agent
 Requires-Python: >=3.10
 Description-Content-Type: text/markdown
 License-File: LICENSE
@@ -42,7 +45,7 @@ Dynamic: license-file
 <p align="center">
   <h1 align="center">📄 hwpx-mcp-server</h1>
   <p align="center">
-    <strong>한글(HWPX) 문서를 AI로 자동화하는 MCP 서버</strong>
+    <strong>AI 에이전트가 HWPX 문서를 바로 읽고, 찾고, 수정하게 만드는 MCP 서버</strong>
   </p>
   <p align="center">
     한글 워드프로세서 없이 · 순수 파이썬 · 크로스 플랫폼
@@ -63,6 +66,14 @@ Dynamic: license-file
 
 <br>
 
+## 이 서버가 바로 해결하는 일
+
+- **Claude Desktop, VS Code, Gemini CLI 같은 MCP 클라이언트에서 HWPX를 바로 읽기**
+- **복사본을 만든 뒤 안전하게 검색·치환·표 편집·문단 추가 수행**
+- **문서 개요, 표 맵, 패키지 구조를 AI가 직접 조회하고 후속 작업으로 연결**
+- **한글 워드프로세서 없이 서버·CI·로컬 개발 환경에서 같은 흐름 유지**
+- **고급 모드에서 검증, package inspection, edit planning까지 확장**
+
 ## 왜 필요한가?
 
 국내 공공기관·학교·기업에서는 한글 문서 기반 업무가 많지만, 자동화는 오랫동안 운영체제와 프로그램에 크게 의존했습니다.
@@ -72,6 +83,8 @@ Dynamic: license-file
 - ✅ **운영체제 무관** — Windows, macOS, Linux에서 동작
 - ✅ **한글 워드프로세서 불필요** — 순수 파이썬 기반 처리
 - ✅ **AI 연동 중심** — Claude Desktop, VS Code, Gemini CLI 등 MCP 클라이언트와 직접 연결
+- ✅ **문서 편집을 도구 호출로 표준화** — 읽기, 편집, 복제, 검증을 MCP 도구 집합으로 노출
+- ✅ **실전 작업 흐름에 맞춘 설계** — read, copy, edit, inspect, validate를 한 서버 표면으로 정리
 - ✅ **일관된 호출 방식** — 도구 호출마다 `filename`을 명시하는 stateless 구조
 
 <br>
@@ -184,6 +197,34 @@ hwpx-mcp-server
 
 <br>
 
+## 작업별 빠른 경로
+
+처음부터 모든 도구를 외울 필요는 없다. 보통은 아래 세 흐름 중 하나로 시작하면 된다.
+
+### 1. 읽기 전용으로 문서를 파악할 때
+
+1. `get_document_info`
+2. `get_document_outline` 또는 `get_document_text`
+3. `find_text`, `get_table_text`, `get_table_map` 같은 읽기 도구로 필요한 부분만 더 본다.
+
+이 흐름은 원본을 저장하지 않는다.
+
+### 2. 안전하게 수정할 때
+
+1. `copy_document`로 작업용 사본을 만든다.
+2. 읽기 도구로 수정 대상을 다시 확인한다.
+3. `search_and_replace`, `batch_replace`, `set_table_cell_text`, `add_paragraph` 같은 가장 작은 변경 도구만 쓴다.
+4. 수정 후 다시 읽기 도구로 결과를 확인한다.
+5. 납품이나 handoff가 필요하면 검토가 끝난 복사본 파일을 그대로 넘긴다.
+
+핵심은 `copy first`, `smallest edit`, `re-read after edits`다.
+
+### 3. 구조 점검과 검증이 목적일 때
+
+1. MCP 설정에서 `HWPX_MCP_ADVANCED=1`
+2. `package_parts`, `package_get_xml`, `package_get_text`로 내부 파트를 본다.
+3. `validate_structure`, `lint_text_conventions`, `plan_edit`, `preview_edit`는 기본 편집 흐름과 섞지 않고 점검/검증 단계에서만 사용한다.
+
 ## 안전한 사용 원칙
 
 이 서버의 공개 표면은 **현재 README에 적힌 MCP 도구 집합**이다. 워크플로 문서나 스킬 예시는 이 도구들을 조합하는 사용 패턴이지, 별도의 새 public tool 계약이 아니다.
@@ -193,12 +234,14 @@ hwpx-mcp-server
 1. 먼저 `get_document_info`, `get_document_text`, `find_text` 같은 읽기 도구로 문서를 파악한다.
 2. 수정 전 결과물을 보존해야 하면 `copy_document`를 먼저 호출한다.
 3. 수정 도구는 **호출 즉시 저장**되므로, 검토용 경로가 필요하면 원본 대신 복사본에서 작업한다.
-4. package inspection, edit planning, validation은 `HWPX_MCP_ADVANCED=1`일 때만 쓰고, 기본 흐름과 섞어 쓰지 않는다.
+4. 결과물을 따로 넘겨야 하면 검토가 끝난 복사본 파일을 handoff 경계로 사용한다.
+5. package inspection, edit planning, validation은 `HWPX_MCP_ADVANCED=1`일 때만 쓰고, 기본 흐름과 섞어 쓰지 않는다.
 
 짧게 말하면:
 - **read first**
 - **copy before risky edits**
 - **mutating tools persist immediately**
+- **explicit handoff uses the reviewed copy**
 - **advanced mode는 점검/검증용으로 분리**
 
 ## 도구 동작 빠른 감각
@@ -206,7 +249,8 @@ hwpx-mcp-server
 | 구분 | 대표 도구 | 특징 |
 |---|---|---|
 | 파일 기반 읽기 전용 | `get_document_info`, `get_document_text`, `get_paragraph_text`, `get_paragraphs_text`, `find_text`, `get_table_text`, `get_table_map`, `find_cell_by_label`, `list_styles`, `list_available_documents` | 기존 `.hwpx` 파일을 읽거나 탐색만 한다. 저장하지 않는다. |
-| 파일 기반 즉시 저장 | `create_document`, `search_and_replace`, `batch_replace`, `add_heading`, `add_paragraph`, `insert_paragraph`, `delete_paragraph`, `add_table`, `fill_by_path`, `set_table_cell_text`, `add_page_break`, `add_memo`, `remove_memo`, `format_text`, `create_custom_style`, `merge_table_cells`, `split_table_cell`, `format_table`, `copy_document` | 호출 결과가 곧 파일 변경이다. 검토용이면 먼저 복사본에서 작업한다. |
+| 파일 기반 즉시 저장 편집 | `create_document`, `search_and_replace`, `batch_replace`, `add_heading`, `add_paragraph`, `insert_paragraph`, `delete_paragraph`, `add_table`, `fill_by_path`, `set_table_cell_text`, `add_page_break`, `add_memo`, `remove_memo`, `format_text`, `create_custom_style`, `merge_table_cells`, `split_table_cell`, `format_table` | 호출 결과가 곧 대상 파일 변경이다. 검토용이면 먼저 복사본에서 작업한다. |
+| 복제 / handoff 경계 | `copy_document` | 원본 보호와 reviewable working copy 분리에 쓴다. 현재 FastMCP surface에는 별도 public `save` / `save_as` tool이 없다. |
 | payload/url 기반 추출 | `hwpx_to_markdown`, `hwpx_to_html`, `hwpx_extract_json` | 파일명을 직접 수정하지 않는다. HWPX payload 또는 URL을 읽어 변환 결과만 돌려준다. |
 | 고급 점검/검증 | `package_parts`, `package_get_xml`, `package_get_text`, `object_find_by_tag`, `object_find_by_attr`, `plan_edit`, `preview_edit`, `apply_edit`, `validate_structure`, `lint_text_conventions` | `HWPX_MCP_ADVANCED=1`일 때만 활성화한다. package/구조 점검용이다. |
 
@@ -237,7 +281,7 @@ hwpx-mcp-server
 
 ### ✏️ 문서 편집
 
-이 카테고리의 도구는 `copy_document`를 제외하면 대체로 원본 파일에 즉시 반영된다. 구조 변경 전에는 복사본을 먼저 만드는 편이 안전하다.
+이 카테고리의 도구는 대체로 대상 파일에 즉시 반영된다. 구조 변경 전에는 `copy_document`로 작업용 사본을 만들고, handoff는 검토가 끝난 복사본 파일 기준으로 잡는 편이 안전하다.
 
 | 도구 | 설명 |
 |---|---|
@@ -245,7 +289,14 @@ hwpx-mcp-server
 | `add_paragraph` / `insert_paragraph` / `delete_paragraph` | 문단 추가, 삽입, 삭제 |
 | `add_page_break` | 페이지 나누기 추가 |
 | `add_memo` / `remove_memo` | 메모 추가, 제거 |
-| `copy_document` | 안전한 사본 생성 후 작업 시작 |
+
+### 💾 복제
+
+이 카테고리는 수정 워크플로의 안전 장치다. 원본 보호와 reviewable working copy 분리에 쓴다.
+
+| 도구 | 설명 |
+|---|---|
+| `copy_document` | 원본을 건드리기 전에 작업용 사본 생성 |
 
 ### 📊 표 편집
 
@@ -261,7 +312,7 @@ hwpx-mcp-server
 | `merge_table_cells` / `split_table_cell` | 셀 병합, 분할 |
 | `format_table` | 표 헤더 등 기본 서식 적용 |
 
-변경 도구는 호출 시 즉시 저장됩니다. 검토용 사본이 필요하면 `copy_document`를 먼저 사용하세요.
+변경 도구는 호출 시 즉시 저장됩니다. 검토용 사본이 필요하면 `copy_document`를 먼저 사용하고, 납품본은 검토가 끝난 복사본 파일을 기준으로 관리하세요.
 
 ### 🎨 서식 및 스타일
 

--- a/src/hwpx_mcp_server/server.py
+++ b/src/hwpx_mcp_server/server.py
@@ -49,6 +49,15 @@ from .hwpx_ops import HwpxOps
 from .upstream import HP_NS, create_text_extractor, open_document
 from .utils.helpers import default_max_chars, resolve_path, truncate_response
 
+try:  # python-hwpx >= proposal preset feature
+    from hwpx.presets import (
+        create_proposal_document as build_proposal_document,
+        inspect_proposal_quality as inspect_proposal_document_quality,
+    )
+except Exception:  # pragma: no cover - optional dependency compatibility
+    build_proposal_document = None
+    inspect_proposal_document_quality = None
+
 mcp = FastMCP("hwpx-mcp-server")
 
 
@@ -671,6 +680,51 @@ def create_document(filename: str, title: str = None, author: str = None) -> dic
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     create_blank(path)
     return {"filename": filename, "created": True}
+
+
+@mcp.tool()
+def create_proposal_document(
+    filename: str,
+    proposal_spec: dict,
+    style_preset: str = "clean_korean_proposal",
+) -> dict:
+    """자연어에서 추출한 proposal_spec으로 제안서형 HWPX 문서를 생성합니다."""
+    if build_proposal_document is None:
+        raise RuntimeError(
+            "installed python-hwpx does not provide hwpx.presets proposal support"
+        )
+    path = resolve_path(filename)
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    doc = build_proposal_document(proposal_spec or {}, preset=style_preset)
+    try:
+        doc.save_to_path(path)
+    finally:
+        doc.close()
+
+    report = (
+        inspect_proposal_document_quality(path)
+        if inspect_proposal_document_quality is not None
+        else None
+    )
+    return {
+        "filename": filename,
+        "created": True,
+        "style_preset": style_preset,
+        "quality": report,
+    }
+
+
+@mcp.tool()
+def inspect_document_quality(filename: str, rubric: str = "proposal") -> dict:
+    """생성된 HWPX 문서를 제안서 품질 루브릭으로 점검합니다."""
+    if rubric != "proposal":
+        raise ValueError("rubric must be 'proposal'")
+    if inspect_proposal_document_quality is None:
+        raise RuntimeError(
+            "installed python-hwpx does not provide proposal quality inspection"
+        )
+    path = resolve_path(filename)
+    return inspect_proposal_document_quality(path)
 
 
 @mcp.tool()

--- a/tests/test_proposal_tools.py
+++ b/tests/test_proposal_tools.py
@@ -1,0 +1,35 @@
+from hwpx_mcp_server import server
+
+
+def _spec() -> dict:
+    return {
+        "title": "AI 융합형 교육실 구축 제안서",
+        "organization": "샘플 고등학교",
+        "author": "교육혁신팀",
+        "date": "2026-05-06",
+        "executive_summary": "AI 융합형 교육실 구축을 통해 맞춤형 수업 환경을 조성합니다.",
+        "sections": [
+            {"title": "추진 배경 및 문제 정의", "paragraphs": ["기존 실습 환경의 한계를 개선합니다."]},
+            {"title": "제안 내용", "paragraphs": ["AI 실습 공간과 운영 프로그램을 함께 제안합니다."]},
+            {"title": "구축 및 운영 계획", "paragraphs": ["준비, 구축, 운영, 평가 단계로 추진합니다."]},
+        ],
+        "budget_items": [{"item": "기자재", "amount": "5,000,000원", "note": "노트북"}],
+        "expected_outcomes": ["참여형 수업 확대"],
+        "closing": "검토 후 승인 요청드립니다.",
+    }
+
+
+def test_create_and_inspect_proposal_document(tmp_path, monkeypatch):
+    monkeypatch.setenv("HWPX_MCP_SANDBOX_ROOT", str(tmp_path))
+    filename = str(tmp_path / "proposal.hwpx")
+    result = server.create_proposal_document(filename, _spec())
+
+    assert result["created"] is True
+    assert result["quality"]["rubric_average"] >= 4.0
+    assert result["quality"]["report_version"] == "proposal-quality-v2"
+    assert result["quality"]["sample_match"]["pass"] is True
+
+    inspection = server.inspect_document_quality(filename)
+    assert inspection["outline"]["required_sections_present"] is True
+    assert inspection["table_checks"]["has_budget_table"] is True
+    assert inspection["sample_match"]["visual_review_required"] is True


### PR DESCRIPTION
## What changed

- Adds MCP proposal tools that call through to `python-hwpx` `hwpx.presets`:
  - `create_proposal_document`
  - `inspect_document_quality`
- Includes the safe form-fill workflow imported by the server surface and its E2E regression coverage.
- Documents the v2 sample-match quality report and its `visual_review_required` limitation.

## Why

Agents using MCP need a stable tool surface for creating and inspecting proposal/planning HWPX documents, while keeping document-quality algorithms in `python-hwpx`.

## Validation

- `PYTHONPATH=/Users/wilycastle/Code/projects/python-hwpx/src:/Users/wilycastle/Code/projects/hwpx-mcp-server/src .venv/bin/python -m pytest -q` → passed

## Notes

The MCP server remains a thin consumer of the core `python-hwpx` report shape; rendered visual parity is still outside this no-renderer phase.
