### PR TITLE
[codex] Expose document ingest and markdown plan bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ pip install hwpx-mcp-server
 hwpx-mcp-server
 ```
 
+비-HWPX 문서(PDF/DOCX/XLSX/HTML/TXT)를 `document_to_markdown` 경로로 읽으려면 MarkItDown adapter extra를 함께 설치합니다.
+
+```bash
+pip install "hwpx-mcp-server[ingest]"
+```
+
 요구 사항: `Python >= 3.10` · `python-hwpx >= 2.23.0`
 
 ### MCP 클라이언트 설정
@@ -111,6 +117,7 @@ hwpx-mcp-server
 기본 모드에서 다수의 HWPX 도구를 제공하며, 고급 모드(`HWPX_MCP_ADVANCED=1`)에서 점검·검증용 도구가 추가됩니다. 아래는 테마별 대표 하이라이트입니다. **전체 도구 목록·시그니처는 [`docs/use-cases.md`](docs/use-cases.md)와 [`docs/skill-first-workflows.md`](docs/skill-first-workflows.md)를 참고하세요.**
 
 - **📖 읽기·탐색** — `get_document_info`, `get_document_text`, `get_document_outline`, `find_text`, `get_table_text`, `get_table_map`, `find_cell_by_label`, `list_styles`. `get_document_map`은 아웃라인·표 지도·누름틀·앵커를 한 호출로 반환(왕복 최소화). (저장하지 않음)
+- **📥 로컬 문서 ingest** — `document_to_markdown`, `document_extract_json`, `markdown_to_document_plan`이 로컬 문서를 Markdown/JSON/document plan으로 변환합니다. HWPX는 `python-hwpx` 엔진을 우선 사용하고, 비-HWPX는 `[ingest]` extra 설치 시 MarkItDown adapter로 처리합니다.
 - **🔎 검색·치환** — `search_and_replace`, `batch_replace`, `replace_in_paragraph`, `replace_by_anchor`. (`find_text` 외 즉시 저장)
 - **✏️ 편집·트랜잭션** — `add_heading`, `add_paragraph`/`insert_paragraph`/`delete_paragraph`, `add_page_break`, `add_memo` 계열. `apply_edits`는 연산 목록 원자 적용(중간 실패 시 전체 롤백·`dry_run`·`expected_revision` 동시성 가드·`idempotency_key`), `undo_last_edit`는 `.bak` 복원, `byte_preserving_patch`는 미수정 영역 바이트 보존, `add_tracked_edit`는 변경 추적(redline).
 - **📊 표·양식채움** — `add_table`, `set_table_cell_text`, `merge_table_cells`/`split_table_cell`, `format_table`, `table_compute`(합계·평균·소계), `fill_by_path`(`성명 > right` 경로 구문). **바이트 보존 구조적 양식채움**: 셀 바이트 채움(빈/다중 문단)·행/열/표 삭제·복제 삽입·열 너비 자동맞춤·폰트 축소맞춤을 양식 서식을 재구성하지 않고 그대로 보존하며 수행하고 실제 한컴으로 검증(`verify_fill`). `analyze_template_formfit`/`apply_template_formfit`은 승인된 양식을 원본과 다른 destination에만 반영.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
 hwp = ["olefile>=0.47"]
 # HTTP/streamable transport. The default stdio transport needs no extra.
 http = ["uvicorn>=0.30"]
+# General non-HWPX document ingest through Microsoft's MarkItDown. Lazy-imported.
+ingest = ["markitdown[all]>=0.1.6"]
 # 직인 날인/검증의 한컴 렌더 오라클 경로(렌더→fitz word/image bbox). macOS+Hancom 필요;
 # 없으면 place_seal/check_seal_compliance가 renderChecked=false로 정직하게 degrade한다.
 oracle = ["python-hwpx[visual]>=2.23.0"]

--- a/src/hwpx_mcp_server/ingest_adapters.py
+++ b/src/hwpx_mcp_server/ingest_adapters.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional document-ingest adapters for the MCP server layer."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from hwpx.ingest import (
+    DocumentIngestError,
+    DocumentIngestResult,
+    DocumentSourceInfo,
+)
+
+
+class MissingMarkItDownDependency(DocumentIngestError):
+    """Raised when the optional MarkItDown runtime is not installed."""
+
+
+class MarkItDownAdapter:
+    """Fallback converter that delegates non-HWPX sources to Microsoft MarkItDown."""
+
+    name = "MarkItDownAdapter"
+
+    def accepts(self, file_stream: BinaryIO, source_info: DocumentSourceInfo) -> bool:
+        del file_stream
+        extension = (source_info.extension or "").lower()
+        return extension != ".hwpx"
+
+    def convert(
+        self,
+        file_stream: BinaryIO,
+        source_info: DocumentSourceInfo,
+        **kwargs: Any,
+    ) -> DocumentIngestResult:
+        del kwargs
+        markitdown_cls = _load_markitdown_class()
+        source_path = _source_path(file_stream, source_info)
+        result = markitdown_cls().convert(str(source_path))
+        markdown = _extract_markdown(result)
+        return DocumentIngestResult(
+            markdown=markdown,
+            source_info=source_info,
+            source_format=(source_info.extension or "unknown").lstrip(".") or "unknown",
+            engine="markitdown",
+            metadata={"converter": self.name},
+            warnings=[
+                "Converted by optional MarkItDown adapter; layout fidelity is not claimed.",
+            ],
+            lossiness="unknown",
+        )
+
+
+def _load_markitdown_class() -> type:
+    try:
+        from markitdown import MarkItDown
+    except ImportError as exc:
+        raise MissingMarkItDownDependency(
+            "install hwpx-mcp-server[ingest] to enable non-HWPX document ingest"
+        ) from exc
+    return MarkItDown
+
+
+def _source_path(file_stream: BinaryIO, source_info: DocumentSourceInfo) -> Path:
+    if source_info.local_path:
+        return Path(source_info.local_path)
+
+    suffix = source_info.extension or ""
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        start_pos = file_stream.tell()
+        tmp.write(file_stream.read())
+        file_stream.seek(start_pos)
+        return Path(tmp.name)
+
+
+def _extract_markdown(result: Any) -> str:
+    for attr in ("text_content", "markdown", "text"):
+        value = getattr(result, attr, None)
+        if isinstance(value, str):
+            return value
+    if isinstance(result, str):
+        return result
+    raise ValueError("MarkItDown result did not include Markdown text")

--- a/src/hwpx_mcp_server/markdown_plan.py
+++ b/src/hwpx_mcp_server/markdown_plan.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Markdown-to-document-plan bridge."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownPlanResult:
+    plan: dict[str, Any]
+    warnings: list[str]
+
+
+def markdown_to_document_plan(
+    markdown: str,
+    *,
+    title: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    style_preset: str = "standard_korean_business",
+) -> MarkdownPlanResult:
+    """Convert a conservative Markdown subset into ``hwpx.document_plan.v1``."""
+
+    warnings: list[str] = []
+    blocks: list[dict[str, Any]] = []
+    lines = (markdown or "").replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    resolved_title = (title or "").strip()
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped:
+            index += 1
+            continue
+
+        if table := _parse_table(lines, index):
+            table_block, next_index = table
+            blocks.append(table_block)
+            index = next_index
+            continue
+
+        heading = _parse_heading(stripped)
+        if heading is not None:
+            level, text = heading
+            if not resolved_title and level == 1 and not blocks:
+                resolved_title = text
+            else:
+                blocks.append({"type": "heading", "level": min(level, 3), "text": text})
+                if level > 3:
+                    warnings.append(f"Heading level {level} was clamped to document_plan level 3.")
+            index += 1
+            continue
+
+        if _is_list_item(stripped):
+            items, next_index, ordered = _collect_list(lines, index)
+            blocks.append({"type": "bullets", "items": items})
+            if ordered:
+                warnings.append("Ordered Markdown lists were converted to bullet blocks.")
+            index = next_index
+            continue
+
+        paragraph, next_index = _collect_paragraph(lines, index)
+        if paragraph:
+            blocks.append({"type": "paragraph", "text": paragraph})
+        index = next_index
+
+    if not resolved_title:
+        resolved_title = _title_from_blocks(blocks) or "Markdown Import"
+
+    if not blocks:
+        blocks.append({"type": "paragraph", "text": "작성 필요"})
+        warnings.append("Markdown had no content blocks; inserted an empty paragraph placeholder.")
+
+    quality_gates = {
+        "validatePackage": True,
+        "validateDocument": True,
+        "reopen": True,
+        "minNonEmptyParagraphs": max(1, _non_empty_block_count(blocks)),
+        "visualReviewRequired": True,
+    }
+    return MarkdownPlanResult(
+        plan={
+            "schemaVersion": "hwpx.document_plan.v1",
+            "title": resolved_title,
+            "metadata": _string_metadata(metadata or {}),
+            "stylePreset": style_preset,
+            "blocks": blocks,
+            "qualityGates": quality_gates,
+        },
+        warnings=warnings,
+    )
+
+
+def _parse_heading(stripped: str) -> tuple[int, str] | None:
+    match = re.match(r"^(#{1,6})\s+(.+?)\s*#*\s*$", stripped)
+    if not match:
+        return None
+    return len(match.group(1)), match.group(2).strip()
+
+
+def _is_list_item(stripped: str) -> bool:
+    return bool(re.match(r"^([-+*])\s+.+", stripped) or re.match(r"^\d+[.)]\s+.+", stripped))
+
+
+def _collect_list(lines: list[str], index: int) -> tuple[list[str], int, bool]:
+    items: list[str] = []
+    ordered = False
+    while index < len(lines):
+        stripped = lines[index].strip()
+        unordered = re.match(r"^[-+*]\s+(.+)$", stripped)
+        numbered = re.match(r"^\d+[.)]\s+(.+)$", stripped)
+        if unordered:
+            items.append(unordered.group(1).strip())
+        elif numbered:
+            ordered = True
+            items.append(numbered.group(1).strip())
+        else:
+            break
+        index += 1
+    return items, index, ordered
+
+
+def _collect_paragraph(lines: list[str], index: int) -> tuple[str, int]:
+    parts: list[str] = []
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if not stripped or _parse_heading(stripped) or _is_list_item(stripped) or _parse_table(lines, index):
+            break
+        parts.append(stripped)
+        index += 1
+    return " ".join(parts).strip(), index
+
+
+def _parse_table(lines: list[str], index: int) -> tuple[dict[str, Any], int] | None:
+    if index + 1 >= len(lines):
+        return None
+    header = lines[index].strip()
+    divider = lines[index + 1].strip()
+    if not _looks_like_table_row(header) or not _looks_like_divider(divider):
+        return None
+
+    labels = _split_table_row(header)
+    if not labels:
+        return None
+    keys = [f"col{col_index + 1}" for col_index in range(len(labels))]
+    rows: list[dict[str, str]] = []
+    index += 2
+    while index < len(lines) and _looks_like_table_row(lines[index].strip()):
+        cells = _split_table_row(lines[index].strip())
+        row = {
+            key: cells[col_index].strip() if col_index < len(cells) else ""
+            for col_index, key in enumerate(keys)
+        }
+        rows.append(row)
+        index += 1
+
+    return {
+        "type": "table",
+        "columns": [
+            {"key": key, "label": label.strip() or key}
+            for key, label in zip(keys, labels)
+        ],
+        "rows": rows,
+    }, index
+
+
+def _looks_like_table_row(line: str) -> bool:
+    return "|" in line and len(_split_table_row(line)) >= 2
+
+
+def _looks_like_divider(line: str) -> bool:
+    cells = _split_table_row(line)
+    return bool(cells) and all(re.match(r"^:?-{3,}:?$", cell.strip()) for cell in cells)
+
+
+def _split_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.replace(r"\|", "|").strip() for cell in stripped.split("|")]
+
+
+def _title_from_blocks(blocks: list[dict[str, Any]]) -> str:
+    for block in blocks:
+        text = str(block.get("text") or "").strip()
+        if block.get("type") == "heading" and text:
+            return text
+    for block in blocks:
+        text = str(block.get("text") or "").strip()
+        if text:
+            return text[:80]
+    return ""
+
+
+def _string_metadata(metadata: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        str(key): str(value)
+        for key, value in metadata.items()
+        if value is not None and str(value).strip()
+    }
+
+
+def _non_empty_block_count(blocks: list[dict[str, Any]]) -> int:
+    count = 0
+    for block in blocks:
+        kind = block.get("type")
+        if kind in {"heading", "paragraph"} and str(block.get("text") or "").strip():
+            count += 1
+        elif kind == "bullets":
+            count += len(block.get("items") or [])
+    return count

--- a/src/hwpx_mcp_server/server.py
+++ b/src/hwpx_mcp_server/server.py
@@ -138,6 +138,15 @@ except Exception:  # pragma: no cover - optional dependency compatibility
     normalize_hwpx_document_plan = None
     validate_hwpx_document_plan = None
 
+try:  # python-hwpx >= MarkItDown-style ingest gateway
+    from hwpx.ingest import (
+        DocumentIngestError,
+        DocumentIngestor,
+    )
+except Exception:  # pragma: no cover - optional dependency compatibility
+    DocumentIngestError = None
+    DocumentIngestor = None
+
 try:  # python-hwpx >= official-document style lint feature
     from hwpx import (
         inspect_official_document_style as inspect_hwpx_official_document_style,
@@ -1063,6 +1072,11 @@ def _markdown_chunks(model: dict[str, Any], *, chunk_strategy: str, max_chars_pe
     return _chunk_paragraphs(paragraphs, max_chars_per_chunk)
 
 
+def _ingest_markdown_chunks(markdown: str, *, max_chars_per_chunk: int) -> list[str]:
+    paragraphs = [part for part in re.split(r"\n{2,}", markdown or "") if part.strip()]
+    return _chunk_paragraphs(paragraphs, max_chars_per_chunk)
+
+
 def _html_chunks(model: dict[str, Any], *, chunk_strategy: str, max_chars_per_chunk: int) -> list[str]:
     if chunk_strategy == "section":
         chunks = [_section_html(section) for section in model["sections"]]
@@ -1117,6 +1131,63 @@ def _build_conversion_meta(model: dict[str, Any], source_meta: dict[str, Any]) -
         "table_count": len(model["tables"]),
         "figure_caption_count": len(model["figures"]),
     }
+
+
+def _ingest_local_document(filename: str):
+    if DocumentIngestor is None:
+        raise RuntimeError("installed python-hwpx does not provide document ingest")
+    from .ingest_adapters import MarkItDownAdapter, MissingMarkItDownDependency
+
+    path = resolve_path(filename)
+    ingestor = DocumentIngestor.default()
+    ingestor.register_converter(MarkItDownAdapter(), priority=100.0)
+    try:
+        return path, ingestor.convert(path)
+    except DocumentIngestError as exc:
+        for attempt in getattr(exc, "attempts", []) or []:
+            if getattr(attempt, "error_type", None) == "MissingMarkItDownDependency":
+                raise MissingMarkItDownDependency(str(attempt.message), attempts=exc.attempts) from exc
+        raise
+
+
+def _document_ingest_error_payload(exc: Exception, filename: str) -> dict[str, Any]:
+    if DocumentIngestError is not None and isinstance(exc, DocumentIngestError):
+        payload = exc.as_dict()
+    else:
+        payload = {"error": type(exc).__name__, "message": str(exc), "attempts": []}
+    payload.update({"ok": False, "filename": filename})
+    return payload
+
+
+def _document_ingest_meta(result: Any) -> dict[str, Any]:
+    source_info = getattr(result, "source_info", None)
+    meta = {
+        "source_format": getattr(result, "source_format", None),
+        "engine": getattr(result, "engine", None),
+        "engine_version": getattr(result, "engine_version", None),
+        "lossiness": getattr(result, "lossiness", None),
+    }
+    if source_info is not None:
+        meta["source_info"] = {
+            "mimetype": getattr(source_info, "mimetype", None),
+            "extension": getattr(source_info, "extension", None),
+            "charset": getattr(source_info, "charset", None),
+            "filename": getattr(source_info, "filename", None),
+            "local_path": getattr(source_info, "local_path", None),
+            "url": getattr(source_info, "url", None),
+        }
+    metadata = getattr(result, "metadata", None)
+    if isinstance(metadata, dict):
+        meta.update(metadata)
+    return {key: value for key, value in meta.items() if value is not None}
+
+
+def _attempts_payload(result: Any) -> list[dict[str, Any]]:
+    attempts = getattr(result, "attempts", []) or []
+    return [
+        attempt.as_dict() if hasattr(attempt, "as_dict") else dict(attempt)
+        for attempt in attempts
+    ]
 
 
 def _paragraph_count(doc) -> int:
@@ -1391,6 +1462,44 @@ def validate_document_plan(document_plan: dict) -> dict:
         result["next_tool"] = "validate_document_plan"
         result["next_action"] = (
             "repair document_plan using repairHints, then rerun validate_document_plan"
+        )
+    return result
+
+
+@mcp.tool()
+def markdown_to_document_plan(
+    markdown: str,
+    title: str = None,
+    metadata: dict = None,
+    style_preset: str = "standard_korean_business",
+) -> dict:
+    """Markdown을 검증 가능한 hwpx.document_plan.v1 초안으로 변환합니다. 파일은 쓰지 않습니다."""
+    if validate_hwpx_document_plan is None or normalize_hwpx_document_plan is None:
+        raise RuntimeError("installed python-hwpx does not provide document-plan authoring")
+    from .markdown_plan import markdown_to_document_plan as _build_markdown_document_plan
+
+    converted = _build_markdown_document_plan(
+        markdown or "",
+        title=title,
+        metadata=metadata or {},
+        style_preset=style_preset,
+    )
+    plan = converted.plan
+    report = validate_hwpx_document_plan(plan)
+    validation = report.to_dict()
+    result: dict[str, Any] = {
+        "ok": report.ok,
+        "can_create": report.ok,
+        "document_plan": plan,
+        "validation": validation,
+        "warnings": list(converted.warnings),
+        "next_tool": "create_document_from_plan" if report.ok else "markdown_to_document_plan",
+    }
+    if report.ok:
+        result["normalizedPlan"] = normalize_hwpx_document_plan(plan).to_dict()
+    else:
+        result["next_action"] = (
+            "repair Markdown or document_plan using validation.repairHints, then rerun markdown_to_document_plan"
         )
     return result
 
@@ -2481,6 +2590,43 @@ def hwpx_to_markdown(
 
 
 @mcp.tool()
+def document_to_markdown(
+    filename: str,
+    output: str = "full",
+    chunk_strategy: str = "section",
+    max_chars_per_chunk: int | None = None,
+    mask: bool = True,
+) -> dict:
+    """로컬 문서를 Markdown으로 변환합니다. 현재 HWPX는 python-hwpx ingest 엔진으로 처리합니다."""
+    mode = _normalize_output_mode(output)
+    strategy = _normalize_chunk_strategy(chunk_strategy)
+    chunk_size = _resolve_chunk_size(max_chars_per_chunk)
+
+    try:
+        path, ingest_result = _ingest_local_document(filename)
+    except Exception as exc:
+        return _document_ingest_error_payload(exc, filename)
+
+    markdown = _mask_pii_text(ingest_result.markdown, mask)
+    payload: dict[str, Any] = {
+        "ok": True,
+        "filename": str(path),
+        "markdown": markdown,
+        "meta": _document_ingest_meta(ingest_result),
+        "warnings": list(getattr(ingest_result, "warnings", []) or []),
+        "attempts": _attempts_payload(ingest_result),
+    }
+    if mode == "chunks":
+        payload["chunks"] = _deep_mask_pii(
+            _ingest_markdown_chunks(markdown, max_chars_per_chunk=chunk_size),
+            mask,
+        )
+        payload["meta"]["chunk_strategy"] = strategy
+        payload["meta"]["max_chars_per_chunk"] = chunk_size
+    return payload
+
+
+@mcp.tool()
 def hwpx_to_html(
     hwpx_base64: str | None = None,
     url: str | None = None,
@@ -2601,6 +2747,55 @@ def hwpx_extract_json(
         result["meta"]["chunk_strategy"] = strategy
         result["meta"]["max_chars_per_chunk"] = chunk_size
     return result
+
+
+@mcp.tool()
+def document_extract_json(
+    filename: str,
+    output: str = "full",
+    chunk_strategy: str = "section",
+    max_chars_per_chunk: int | None = None,
+    format_detail: bool = False,
+    mask: bool = True,
+) -> dict:
+    """로컬 문서에서 Markdown과 구조화된 JSON을 함께 추출합니다. 현재 HWPX ingest를 우선 사용합니다."""
+    del format_detail
+    mode = _normalize_output_mode(output)
+    strategy = _normalize_chunk_strategy(chunk_strategy)
+    chunk_size = _resolve_chunk_size(max_chars_per_chunk)
+
+    try:
+        path, ingest_result = _ingest_local_document(filename)
+    except Exception as exc:
+        return _document_ingest_error_payload(exc, filename)
+
+    markdown = _mask_pii_text(ingest_result.markdown, mask)
+    doc_payload = _deep_mask_pii(
+        {
+            "title": getattr(ingest_result, "title", None),
+            "markdown": markdown,
+            "sections": getattr(ingest_result, "sections", []) or [],
+            "tables": getattr(ingest_result, "tables", []) or [],
+            "metadata": getattr(ingest_result, "metadata", {}) or {},
+        },
+        mask,
+    )
+    payload: dict[str, Any] = {
+        "ok": True,
+        "filename": str(path),
+        "doc": doc_payload,
+        "meta": _document_ingest_meta(ingest_result),
+        "warnings": list(getattr(ingest_result, "warnings", []) or []),
+        "attempts": _attempts_payload(ingest_result),
+    }
+    if mode == "chunks":
+        payload["chunks"] = _deep_mask_pii(
+            _ingest_markdown_chunks(markdown, max_chars_per_chunk=chunk_size),
+            mask,
+        )
+        payload["meta"]["chunk_strategy"] = strategy
+        payload["meta"]["max_chars_per_chunk"] = chunk_size
+    return payload
 
 
 @mcp.tool()

--- a/tests/test_document_ingest_mcp.py
+++ b/tests/test_document_ingest_mcp.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hwpx_mcp_server import ingest_adapters
+import hwpx_mcp_server.server as server
+
+
+def _sample_hwpx(tmp_path: Path) -> Path:
+    target = tmp_path / "document_ingest_sample.hwpx"
+    server.create_document(str(target))
+    server.add_heading(str(target), "Project Report", level=1)
+    server.add_paragraph(str(target), "Overview paragraph.")
+    server.add_table(str(target), 2, 2, [["Name", "Value"], ["A", "1"]])
+    return target
+
+
+def test_document_to_markdown_from_local_hwpx(tmp_path: Path) -> None:
+    target = _sample_hwpx(tmp_path)
+
+    result = server.document_to_markdown(str(target))
+
+    assert result["ok"] is True
+    assert "Project Report" in result["markdown"]
+    assert "| Name | Value |" in result["markdown"]
+    assert result["meta"]["source_format"] == "hwpx"
+    assert result["meta"]["engine"] == "python-hwpx"
+    assert result["meta"]["table_count"] == 1
+    assert result["attempts"][0]["converter"] == "HwpxMarkdownConverter"
+    assert result["attempts"][0]["accepted"] is True
+
+
+def test_document_to_markdown_chunks_paragraph_strategy(tmp_path: Path) -> None:
+    target = _sample_hwpx(tmp_path)
+
+    result = server.document_to_markdown(
+        str(target),
+        output="chunks",
+        chunk_strategy="paragraph",
+        max_chars_per_chunk=32,
+    )
+
+    assert result["ok"] is True
+    assert result["chunks"]
+    assert result["meta"]["chunk_strategy"] == "paragraph"
+    assert result["meta"]["max_chars_per_chunk"] == 32
+
+
+def test_document_extract_json_from_local_hwpx(tmp_path: Path) -> None:
+    target = _sample_hwpx(tmp_path)
+
+    result = server.document_extract_json(str(target))
+
+    assert result["ok"] is True
+    assert "Project Report" in result["doc"]["markdown"]
+    assert result["doc"]["tables"][0]["data"][1] == ["A", "1"]
+    assert result["meta"]["source_format"] == "hwpx"
+
+
+def test_document_to_markdown_uses_markitdown_adapter_for_non_hwpx(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _FakeMarkItDown:
+        def convert(self, path: str):
+            assert path.endswith("sample.txt")
+            return type("FakeResult", (), {"text_content": "# Converted\n\nPlain text body."})()
+
+    monkeypatch.setattr(ingest_adapters, "_load_markitdown_class", lambda: _FakeMarkItDown)
+    target = tmp_path / "sample.txt"
+    target.write_text("plain text", encoding="utf-8")
+
+    result = server.document_to_markdown(str(target))
+
+    assert result["ok"] is True
+    assert result["markdown"] == "# Converted\n\nPlain text body."
+    assert result["meta"]["source_format"] == "txt"
+    assert result["meta"]["engine"] == "markitdown"
+    assert result["warnings"] == [
+        "Converted by optional MarkItDown adapter; layout fidelity is not claimed.",
+    ]
+    assert result["attempts"][0]["converter"] == "HwpxMarkdownConverter"
+    assert result["attempts"][0]["accepted"] is False
+    assert result["attempts"][1]["converter"] == "MarkItDownAdapter"
+    assert result["attempts"][1]["accepted"] is True
+
+
+def test_document_to_markdown_reports_missing_markitdown_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def _missing_markitdown():
+        raise ingest_adapters.MissingMarkItDownDependency("install hwpx-mcp-server[ingest]")
+
+    monkeypatch.setattr(ingest_adapters, "_load_markitdown_class", _missing_markitdown)
+    target = tmp_path / "sample.txt"
+    target.write_text("plain text", encoding="utf-8")
+
+    result = server.document_to_markdown(str(target))
+
+    assert result["ok"] is False
+    assert result["error"] == "MissingMarkItDownDependency"
+    assert "hwpx-mcp-server[ingest]" in result["message"]
+    assert result["attempts"][0]["converter"] == "HwpxMarkdownConverter"
+    assert result["attempts"][0]["accepted"] is False
+    assert result["attempts"][1]["converter"] == "MarkItDownAdapter"
+    assert result["attempts"][1]["accepted"] is True
+    assert result["attempts"][1]["error_type"] == "MissingMarkItDownDependency"

--- a/tests/test_document_plan_mcp_e2e.py
+++ b/tests/test_document_plan_mcp_e2e.py
@@ -184,6 +184,7 @@ def test_document_plan_tools_are_exposed() -> None:
 
     assert {
         "analyze_document_plan",
+        "markdown_to_document_plan",
         "validate_document_plan",
         "create_document_from_plan",
         "inspect_document_authoring_quality",

--- a/tests/test_markdown_plan_mcp.py
+++ b/tests/test_markdown_plan_mcp.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import hwpx_mcp_server.server as server
+
+
+def test_markdown_to_document_plan_builds_valid_plan() -> None:
+    markdown = """# 2026 Operating Plan
+
+Intro paragraph.
+
+## Tasks
+
+- Validate before handoff.
+- Keep review explicit.
+
+| Item | Amount |
+| --- | --- |
+| Devices | 100 |
+"""
+
+    result = server.markdown_to_document_plan(
+        markdown,
+        metadata={"author": "Agent"},
+    )
+
+    plan = result["document_plan"]
+    assert result["ok"] is True
+    assert result["can_create"] is True
+    assert result["next_tool"] == "create_document_from_plan"
+    assert plan["title"] == "2026 Operating Plan"
+    assert plan["metadata"]["author"] == "Agent"
+    assert [block["type"] for block in plan["blocks"]] == [
+        "paragraph",
+        "heading",
+        "bullets",
+        "table",
+    ]
+    assert plan["blocks"][3]["columns"][0]["label"] == "Item"
+    assert plan["blocks"][3]["rows"][0]["col2"] == "100"
+    assert result["normalizedPlan"]["schemaVersion"] == "hwpx.document_plan.v1"
+
+
+def test_markdown_to_document_plan_warns_for_lossy_markdown_shapes() -> None:
+    markdown = """#### Deep Section
+
+1. First
+2. Second
+"""
+
+    result = server.markdown_to_document_plan(markdown)
+
+    assert result["ok"] is True
+    assert result["document_plan"]["title"] == "Deep Section"
+    assert result["document_plan"]["blocks"][0] == {
+        "type": "heading",
+        "level": 3,
+        "text": "Deep Section",
+    }
+    assert any("clamped" in warning for warning in result["warnings"])
+    assert any("Ordered Markdown lists" in warning for warning in result["warnings"])
+
+
+def test_markdown_document_plan_can_create_hwpx(tmp_path: Path) -> None:
+    target = tmp_path / "from_markdown.hwpx"
+    result = server.markdown_to_document_plan(
+        "# Project Report\n\nOverview paragraph.\n\n| Name | Value |\n| --- | --- |\n| A | 1 |"
+    )
+
+    create_result = server.create_document_from_plan(str(target), result["document_plan"])
+
+    assert create_result["created"] is True
+    assert target.exists()
+    extracted = server.document_to_markdown(str(target))
+    assert "Project Report" in extracted["markdown"]
+    assert "Name" in extracted["markdown"]
+    assert "Value" in extracted["markdown"]
+    assert "| A | 1 |" in extracted["markdown"]


### PR DESCRIPTION
## Summary

Implements spec 013 MCP/server support:

- adds `document_to_markdown` and `document_extract_json` local ingest tools
- adds optional MarkItDown adapter behind the `[ingest]` extra with structured missing-dependency reporting
- adds `markdown_to_document_plan` for conservative Markdown to `hwpx.document_plan.v1` lowering
- documents the ingest extra and local ingest tool surface

## Validation

- `.venv/bin/python -m pytest -q tests/test_document_ingest_mcp.py tests/test_markdown_plan_mcp.py tests/test_read_export_tools.py tests/test_optional_extras.py tests/test_document_plan_mcp_e2e.py::test_document_plan_tools_are_exposed tests/test_mcp_end_to_end.py::test_default_toolset_exposes_phase1_and_hides_advanced`
- `git diff --check --cached`