### PR TITLE
fix: reject degenerate cwd workspace fallback (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Fixed
+- The implicit cwd workspace fallback no longer silently adopts a degenerate
+  current directory. GUI MCP clients launch the server from the filesystem root
+  (`/` on macOS) or the Windows system directory (`C:\Windows\System32`), which
+  made every real document path rejected as "outside the authorized workspace
+  roots" (unusable for unconfigured Windows users) or — at the filesystem root —
+  unbounded, defeating the fail-closed design. When neither
+  `HWPX_MCP_WORKSPACE_ROOTS` nor the legacy `HWPX_MCP_SANDBOX_ROOT` is configured
+  and the cwd is degenerate, `WorkspaceResolver.from_environment` now raises
+  `WORKSPACE_ROOT_INVALID` with an actionable message naming
+  `HWPX_MCP_WORKSPACE_ROOTS` and a short example. Explicit configuration
+  behaviour is unchanged. (#73, refs #56)
+
+### Changed
+- An unconfigured degenerate cwd no longer crashes import or startup:
+  `LocalDocumentStorage` defers the error so the server still boots,
+  `mcp_server_health` reports the misconfiguration, and each document tool call
+  returns the clean `WORKSPACE_ROOT_INVALID`. Explicit configuration errors
+  still fail fast at startup.
+- The README Claude Desktop / MCP client quickstart now sets
+  `HWPX_MCP_WORKSPACE_ROOTS` from the start so new users avoid the cwd fallback.
+
 ## [4.3.0] - 2026-07-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,13 +91,18 @@ pip install "hwpx-mcp-server[ingest]"
   "mcpServers": {
     "hwpx": {
       "command": "uvx",
-      "args": ["hwpx-mcp-server"]
+      "args": ["hwpx-mcp-server"],
+      "env": {
+        "HWPX_MCP_WORKSPACE_ROOTS": "[\"~/Documents\"]"
+      }
     }
   }
 }
 ```
 
-환경 변수를 넘길 때는 `env` 블록을 추가합니다.
+`HWPX_MCP_WORKSPACE_ROOTS`에는 문서가 있는 폴더(절대경로 또는 `~`)를 지정하세요. Windows는 `"[\"C:\\\\hwpx\"]"`처럼 씁니다. 값을 비워 두면 서버는 실행 위치(cwd)를 root로 쓰려 하지만, Claude Desktop 같은 GUI 클라이언트는 서버를 시스템 디렉터리(Windows `C:\Windows\System32`, macOS `/`)에서 띄우므로 이런 degenerate cwd는 거부되고 모든 문서 경로가 막힙니다. 그래서 처음부터 이 값을 설정하는 것을 권장합니다.
+
+환경 변수를 더 넘길 때는 `env` 블록에 항목을 추가합니다.
 
 ```json
 {
@@ -106,9 +111,9 @@ pip install "hwpx-mcp-server[ingest]"
       "command": "uvx",
       "args": ["hwpx-mcp-server"],
       "env": {
+        "HWPX_MCP_WORKSPACE_ROOTS": "[\"~/Documents\"]",
         "HWPX_MCP_MAX_CHARS": "12000",
         "HWPX_MCP_ADVANCED": "0",
-        "HWPX_MCP_WORKSPACE_ROOTS": "[\"/absolute/path/to/workspace\"]",
         "LOG_LEVEL": "INFO"
       }
     }
@@ -174,7 +179,7 @@ pip install "hwpx-mcp-server[ingest]"
 | `HWPX_MCP_MAX_CHARS` | 텍스트 반환 도구 기본 최대 길이 | `10000` |
 | `HWPX_MCP_AUTOBACKUP` | `1`이면 저장 전 `.bak` 백업 생성 | `1` |
 | `HWPX_MCP_ADVANCED` | `1`이면 고급 도구 활성화 | `0` |
-| `HWPX_MCP_WORKSPACE_ROOTS` | 허용할 workspace 절대경로의 JSON 배열(복수 root 지원). 상대경로는 첫 root 기준 | unset(프로세스 cwd) |
+| `HWPX_MCP_WORKSPACE_ROOTS` | 허용할 workspace 절대경로의 JSON 배열(복수 root 지원). 상대경로는 첫 root 기준 | unset → 프로세스 cwd. 단 cwd가 degenerate(파일시스템 루트, Windows 시스템 디렉터리)면 `WORKSPACE_ROOT_INVALID`로 거부하니 이 값 설정을 권장 |
 | `HWPX_MCP_SANDBOX_ROOT` | 단일 root 구버전 호환 변수. 새 설정에서는 `HWPX_MCP_WORKSPACE_ROOTS` 사용 | unset |
 | `HWPX_MCP_FETCH_TIMEOUT_SECONDS` | URL 기반 HWPX fetch timeout | `20.0` |
 | `HWPX_MCP_ALLOW_PRIVATE_NETWORK` | `1`이면 신뢰된 사설/루프백 HTTPS 대상 허용. 링크로컬·metadata·예약 주소는 계속 차단 | `0` |

--- a/scripts/check_architecture_ratchets.py
+++ b/scripts/check_architecture_ratchets.py
@@ -50,7 +50,7 @@ EXPECTED_SERVICE_LINES = {
 
 EXPECTED_FACADE_LINES = {
     "hwpx_ops.py": 1422,
-    "server.py": 276,
+    "server.py": 272,
 }
 
 PRIVATE_ATTRIBUTES = ("_mcp_server", "_tool_manager", "_tools")

--- a/src/hwpx_mcp_server/server.py
+++ b/src/hwpx_mcp_server/server.py
@@ -17,7 +17,6 @@ from .tool_bindings import TOOL_BINDINGS
 from .workspace import (
     WORKSPACE_ROOTS_ENV,
     WorkspaceConfigurationError,
-    WorkspaceResolver,
 )
 
 
@@ -230,20 +229,17 @@ def main(argv: list[str] | None = None) -> None:
     if args.workspace_root:
         os.environ[WORKSPACE_ROOTS_ENV] = json.dumps(args.workspace_root)
     try:
-        resolver = WorkspaceResolver.from_environment()
+        storage = LocalDocumentStorage(auto_backup=False)
     except WorkspaceConfigurationError as exc:
+        # Explicit HWPX_MCP_WORKSPACE_ROOTS / --workspace-root configuration is
+        # invalid: fail fast so the operator fixes the value. An unconfigured
+        # degenerate cwd instead defers inside LocalDocumentStorage so the server
+        # still boots and every document tool call reports WORKSPACE_ROOT_INVALID.
         parser.error(
             f"invalid HWPX workspace configuration: {exc}. "
             f"Set {WORKSPACE_ROOTS_ENV} to existing project directories or launch from the project workspace."
         )
-    _replace_ops(
-        HwpxOps(
-            storage=LocalDocumentStorage(
-                workspace_resolver=resolver,
-                auto_backup=False,
-            )
-        )
-    )
+    _replace_ops(HwpxOps(storage=storage))
 
     selected_transport = args.transport
     if selected_transport == "http":

--- a/src/hwpx_mcp_server/storage.py
+++ b/src/hwpx_mcp_server/storage.py
@@ -12,7 +12,7 @@ import zipfile
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Protocol, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Tuple, cast
 from urllib import error, parse, request
 
 try:  # python-hwpx >= 2.10.3
@@ -34,6 +34,9 @@ else:
 from . import quality as quality_contract
 from .upstream import HwpxDocument, open_document, validate_document_path
 from .workspace import (
+    LEGACY_SANDBOX_ROOT_ENV,
+    WORKSPACE_ROOTS_ENV,
+    WorkspaceConfigurationError,
     WorkspaceMissingParentGuard,
     WorkspaceOutputGuard,
     WorkspaceResolver,
@@ -100,14 +103,42 @@ class LocalDocumentStorage:
     ) -> None:
         if workspace_resolver is not None and base_directory is not None:
             raise ValueError("base_directory and workspace_resolver are mutually exclusive")
-        self.workspace = workspace_resolver or (
-            WorkspaceResolver.from_roots([base_directory])
-            if base_directory is not None
-            else WorkspaceResolver.from_environment()
+        self._deferred_workspace_error: WorkspaceConfigurationError | None = None
+        if workspace_resolver is not None:
+            self._workspace: WorkspaceResolver | None = workspace_resolver
+        elif base_directory is not None:
+            self._workspace = WorkspaceResolver.from_roots([base_directory])
+        else:
+            # Implicit cwd fallback. When neither HWPX_MCP_WORKSPACE_ROOTS nor the
+            # legacy root is configured and the cwd is degenerate (e.g. a GUI MCP
+            # client launched from C:\Windows\System32 or /), defer the actionable
+            # error to first use so import and startup do not crash and
+            # mcp_server_health can still report the misconfiguration.
+            try:
+                self._workspace = WorkspaceResolver.from_environment()
+            except WorkspaceConfigurationError as exc:
+                if (
+                    os.environ.get(WORKSPACE_ROOTS_ENV) is not None
+                    or os.environ.get(LEGACY_SANDBOX_ROOT_ENV) is not None
+                ):
+                    raise
+                self._workspace = None
+                self._deferred_workspace_error = exc
+        self.base_directory = (
+            self._workspace.primary_root
+            if self._workspace is not None
+            else Path(os.devnull)
         )
-        self.base_directory = self.workspace.primary_root
         self._auto_backup = auto_backup
         self._logger = logger or logging.getLogger(__name__)
+
+    @property
+    def workspace(self) -> WorkspaceResolver:
+        if self._workspace is None:
+            # A degenerate/unconfigured cwd fallback deferred this error so the
+            # server could boot; surface it now as a clean WORKSPACE_ROOT_INVALID.
+            raise cast(WorkspaceConfigurationError, self._deferred_workspace_error)
+        return self._workspace
 
     def resolve_path(self, path: str, *, must_exist: bool = True) -> Path:
         return self.workspace.resolve(path, must_exist=must_exist)

--- a/src/hwpx_mcp_server/workspace.py
+++ b/src/hwpx_mcp_server/workspace.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, replace
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePath, PureWindowsPath
 from typing import Iterable
 
 
@@ -306,6 +306,39 @@ def _normalize_roots(values: Iterable[str | os.PathLike[str]]) -> tuple[Path, ..
     return tuple(roots)
 
 
+def _windows_system_root() -> PureWindowsPath | None:
+    """Return the Windows system directory to fence off, or ``None`` elsewhere."""
+
+    if os.name != "nt":
+        return None
+    return PureWindowsPath(os.environ.get("SystemRoot", r"C:\Windows"))
+
+
+def _is_degenerate_cwd(
+    workspace: PurePath,
+    *,
+    system_root: PureWindowsPath | None,
+) -> bool:
+    """Return whether a cwd fallback root is an unusable degenerate location.
+
+    A degenerate root is the filesystem root itself (a path that is its own
+    parent), or — when *system_root* is provided — the Windows system directory
+    or a descendant of it. GUI MCP clients launch servers from such directories
+    (``/`` on macOS, ``C:\\Windows\\System32`` on Windows), which must never
+    become an implicit workspace root. Passing *system_root* explicitly keeps
+    the Windows rule testable on POSIX via ``PureWindowsPath``.
+    """
+
+    if workspace == workspace.parent:
+        return True
+    if system_root is not None:
+        candidate_parts = tuple(part.lower() for part in PureWindowsPath(workspace).parts)
+        system_parts = tuple(part.lower() for part in system_root.parts)
+        if system_parts and candidate_parts[: len(system_parts)] == system_parts:
+            return True
+    return False
+
+
 @dataclass(frozen=True, slots=True)
 class WorkspaceResolver:
     """Resolve relative and absolute paths inside one or more authorized roots."""
@@ -328,6 +361,14 @@ class WorkspaceResolver:
             return cls(_normalize_roots([legacy]), LEGACY_SANDBOX_ROOT_ENV)
 
         process_workspace = cwd or Path.cwd()
+        if _is_degenerate_cwd(process_workspace, system_root=_windows_system_root()):
+            raise WorkspaceConfigurationError(
+                f"the process working directory {os.fspath(process_workspace)!r} is not a "
+                f"usable HWPX workspace root; set {WORKSPACE_ROOTS_ENV} to one or more "
+                "existing document directories "
+                f'(for example {WORKSPACE_ROOTS_ENV}="~/Documents" on macOS/Linux '
+                f'or {WORKSPACE_ROOTS_ENV}="C:\\hwpx" on Windows)'
+            )
         return cls(_normalize_roots([process_workspace]), "process-cwd")
 
     @classmethod

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -825,3 +825,109 @@ def test_process_cwd_is_bounded_fallback(tmp_path: Path, monkeypatch: pytest.Mon
 def test_filesystem_root_authorization_is_rejected(root: Path) -> None:
     with pytest.raises(WorkspaceConfigurationError):
         WorkspaceResolver.from_roots([root])
+
+
+def test_degenerate_filesystem_root_cwd_fallback_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(WORKSPACE_ROOTS_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_SANDBOX_ROOT_ENV, raising=False)
+    with pytest.raises(WorkspaceConfigurationError) as excinfo:
+        WorkspaceResolver.from_environment(cwd=Path(Path("/").anchor))
+    message = str(excinfo.value)
+    assert WORKSPACE_ROOTS_ENV in message
+    # The message must be actionable: it names the env var and shows an example.
+    assert "for example" in message
+    assert excinfo.value.code == "WORKSPACE_ROOT_INVALID"
+
+
+@pytest.mark.parametrize(
+    ("workspace", "expected"),
+    [
+        (PureWindowsPath(r"C:\Windows\System32"), True),
+        (PureWindowsPath(r"C:\Windows"), True),
+        (PureWindowsPath(r"C:\WINDOWS\System32\drivers"), True),
+        (PureWindowsPath("C:\\"), True),
+        (PureWindowsPath(r"C:\Docs\reports"), False),
+        (PureWindowsPath(r"D:\projects\hwpx"), False),
+    ],
+)
+def test_is_degenerate_cwd_detects_windows_system_directory(
+    workspace: PureWindowsPath, expected: bool
+) -> None:
+    # Structured to be testable on POSIX: PureWindowsPath plus an explicit
+    # system root exercise the Windows rule without running on Windows.
+    system_root = PureWindowsPath(r"C:\Windows")
+    assert (
+        workspace_module._is_degenerate_cwd(workspace, system_root=system_root)
+        is expected
+    )
+
+
+def test_is_degenerate_cwd_posix_only_flags_filesystem_root() -> None:
+    assert workspace_module._is_degenerate_cwd(Path("/"), system_root=None) is True
+    assert (
+        workspace_module._is_degenerate_cwd(Path("/srv/docs"), system_root=None)
+        is False
+    )
+
+
+def test_windows_system_directory_cwd_fallback_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(WORKSPACE_ROOTS_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_SANDBOX_ROOT_ENV, raising=False)
+    # Force the Windows system-root fence on POSIX so from_environment itself
+    # rejects a System32 cwd (the real Windows Claude Desktop launch directory).
+    monkeypatch.setattr(
+        workspace_module,
+        "_windows_system_root",
+        lambda: PureWindowsPath(r"C:\Windows"),
+    )
+    with pytest.raises(WorkspaceConfigurationError) as excinfo:
+        WorkspaceResolver.from_environment(cwd=PureWindowsPath(r"C:\Windows\System32"))
+    assert WORKSPACE_ROOTS_ENV in str(excinfo.value)
+
+
+def test_explicit_roots_still_accepted_when_cwd_would_be_degenerate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Explicit configuration must remain unchanged even from a degenerate cwd.
+    monkeypatch.setenv(WORKSPACE_ROOTS_ENV, str(tmp_path))
+    resolver = WorkspaceResolver.from_environment(cwd=Path(Path("/").anchor))
+    assert resolver.roots == (tmp_path,)
+    assert resolver.source == WORKSPACE_ROOTS_ENV
+
+
+def test_unconfigured_degenerate_cwd_storage_defers_until_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hwpx_mcp_server.storage import LocalDocumentStorage
+
+    monkeypatch.delenv(WORKSPACE_ROOTS_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_SANDBOX_ROOT_ENV, raising=False)
+    monkeypatch.chdir(Path("/").anchor)
+
+    # Construction must not raise: the server has to boot so that
+    # mcp_server_health and per-call errors stay reachable on an unconfigured
+    # degenerate cwd. The actionable error is deferred to first use.
+    storage = LocalDocumentStorage(auto_backup=False)
+
+    with pytest.raises(WorkspaceConfigurationError) as excinfo:
+        storage.resolve_path("doc.hwpx")
+    assert excinfo.value.code == "WORKSPACE_ROOT_INVALID"
+    with pytest.raises(WorkspaceConfigurationError):
+        _ = storage.workspace
+
+
+def test_explicit_invalid_env_root_fails_fast_not_deferred(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hwpx_mcp_server.storage import LocalDocumentStorage
+
+    monkeypatch.delenv(LEGACY_SANDBOX_ROOT_ENV, raising=False)
+    monkeypatch.setenv(WORKSPACE_ROOTS_ENV, str(tmp_path / "does-not-exist"))
+    # Explicit configuration errors surface at construction (fail fast); only the
+    # unconfigured cwd fallback is deferred.
+    with pytest.raises(WorkspaceConfigurationError):
+        LocalDocumentStorage(auto_backup=False)


### PR DESCRIPTION
## 원인

`WorkspaceResolver.from_environment()`는 `HWPX_MCP_WORKSPACE_ROOTS`(및 legacy `HWPX_MCP_SANDBOX_ROOT`)가 없으면 프로세스 cwd를 workspace root로 사용합니다. GUI MCP 클라이언트(Claude Desktop 등)는 서버를 다음 위치에서 띄웁니다.

- Windows: `C:\Windows\System32` → 실제 문서 경로가 전부 "outside the authorized workspace roots"로 거부되어 미설정 사용자는 사실상 사용 불가 (#56)
- macOS: `/` → workspace가 파일시스템 전체가 되어 fail-closed 설계가 무력화 (이 경우는 기존에도 `_normalize_roots`가 거부했지만 메시지가 비지침형이었고, import 시점에 크래시)

즉 cwd 폴백이 degenerate한 위치를 조용히 root로 삼는 것이 근본 원인입니다.

## 수정

- **`workspace.py`** — cwd 폴백에서만 degenerate cwd를 탐지합니다(`_is_degenerate_cwd`: 파일시스템 루트 = 자기 자신이 부모인 경로, 또는 Windows 시스템 디렉터리 `%SystemRoot%` 이하). degenerate면 기존 `WorkspaceConfigurationError`(code `WORKSPACE_ROOT_INVALID`)를 `HWPX_MCP_WORKSPACE_ROOTS` 설정 예시가 포함된 지침형 메시지와 함께 raise합니다. 명시적 env 동작은 그대로입니다. Windows 규칙은 `PureWindowsPath` + 명시적 system_root 파라미터로 POSIX에서도 테스트 가능합니다.
- **`storage.py`** — 미설정 degenerate cwd에서 서버가 import/startup에 크래시하지 않도록, `LocalDocumentStorage`가 이 에러를 첫 경로 사용 시점까지 지연합니다(`workspace` property가 접근 시 raise). 그 결과 서버는 부팅되고 `mcp_server_health`는 오구성을 보고하며 모든 문서 도구 호출은 깔끔한 `WORKSPACE_ROOT_INVALID`로 실패합니다. env가 설정된 채 값이 잘못된 경우(명시적 오구성)는 여전히 즉시 실패합니다.
- **`server.py` `main()`** — storage 생성 경로를 통해 위 정책이 적용되도록 정리했습니다(미설정 degenerate cwd는 부팅, 명시적 오구성은 `parser.error`로 즉시 실패).
- **문서** — README 퀵스타트(사용자가 처음 복사하는 블록)에 `HWPX_MCP_WORKSPACE_ROOTS`를 포함하고 한 줄 설명을 추가했습니다. env 변수 표의 기본값 설명도 새 동작에 맞게 갱신, CHANGELOG `[Unreleased]`에 항목을 추가했습니다.

## 테스트

`tests/test_workspace.py`에 케이스 추가:

- cwd `/` (파일시스템 루트) → `WORKSPACE_ROOT_INVALID` + 지침형 메시지
- Windows 시스템 디렉터리(`C:\Windows\System32`, `C:\Windows`, 하위, 드라이브 루트) → 탐지, 일반 폴더는 통과 (순수 헬퍼, cross-platform)
- `from_environment`가 System32 cwd를 거부(monkeypatch로 Windows fence를 POSIX에서 강제)
- 미설정 degenerate cwd에서 `LocalDocumentStorage`는 생성은 성공(부팅)하고 첫 사용 시 `WORKSPACE_ROOT_INVALID`로 실패
- env 설정 시 동작 불변 / env 값이 잘못되면 생성 시점에 즉시 실패

전체 스위트: **741 passed, 3 skipped** (라이브 한컴 오라클 미사용). ruff(E9,F + seam), mypy, pyright(0 errors), `check_public_hygiene.py`, `check_architecture_ratchets.py` 모두 통과. server.py 라인 카운트 감소에 맞춰 architecture ratchet 기대값(276→272) 갱신.

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)