### PR TITLE
Normalize workspace path inputs

### DIFF
--- a/src/hwpx_mcp_server/workspace.py
+++ b/src/hwpx_mcp_server/workspace.py
@@ -320,12 +320,11 @@ def _normalize_path_input(
 
     text = os.fspath(value)
 
-    # Unwrap surrounding quotes only. Quotes are transport decoration, so the
-    # whitespace immediately inside them is decoration too and may be trimmed;
-    # the quoted payload itself is preserved.
+    # Unwrap surrounding quotes only. Whitespace outside the quote wrapper is
+    # transport decoration, while the quoted payload itself is preserved.
     stripped = text.strip()
     if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
-        text = stripped[1:-1].strip()
+        text = stripped[1:-1]
 
     # Only treat the input as a URI when it actually carries the ``file`` scheme.
     # Running URI parsing over ordinary paths is what previously mangled valid

--- a/src/hwpx_mcp_server/workspace.py
+++ b/src/hwpx_mcp_server/workspace.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, replace
 from functools import lru_cache
 from pathlib import Path, PurePath, PureWindowsPath
 from typing import Iterable
+from urllib.parse import unquote, urlsplit
 
 
 WORKSPACE_ROOTS_ENV = "HWPX_MCP_WORKSPACE_ROOTS"
@@ -306,6 +307,28 @@ def _normalize_roots(values: Iterable[str | os.PathLike[str]]) -> tuple[Path, ..
     return tuple(roots)
 
 
+def _normalize_path_input(
+    value: str | os.PathLike[str], *, windows: bool | None = None
+) -> str:
+    """Normalize common local-path forms before workspace authorization."""
+
+    text = os.fspath(value).strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+        text = text[1:-1].strip()
+
+    parsed = urlsplit(text)
+    if parsed.scheme.lower() == "file":
+        path = unquote(parsed.path)
+        text = f"//{parsed.netloc}{path}" if parsed.netloc else path
+
+    use_windows = os.name == "nt" if windows is None else windows
+    if use_windows:
+        if len(text) >= 3 and text[0] == "/" and text[1].isalpha() and text[2] == ":":
+            text = text[1:]
+        text = text.replace("/", "\\")
+    return text
+
+
 def _windows_system_root() -> PureWindowsPath | None:
     """Return the Windows system directory to fence off, or ``None`` elsewhere."""
 
@@ -385,7 +408,7 @@ class WorkspaceResolver:
         return self.roots[0]
 
     def _candidate(self, value: str | os.PathLike[str]) -> Path:
-        text = os.fspath(value)
+        text = _normalize_path_input(value)
         if not text or not text.strip() or "\0" in text:
             raise WorkspacePathError(
                 "workspace path must be a non-empty filesystem path",

--- a/src/hwpx_mcp_server/workspace.py
+++ b/src/hwpx_mcp_server/workspace.py
@@ -310,16 +310,51 @@ def _normalize_roots(values: Iterable[str | os.PathLike[str]]) -> tuple[Path, ..
 def _normalize_path_input(
     value: str | os.PathLike[str], *, windows: bool | None = None
 ) -> str:
-    """Normalize common local-path forms before workspace authorization."""
+    """Normalize common local-path forms before workspace authorization.
 
-    text = os.fspath(value).strip()
-    if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
-        text = text[1:-1].strip()
+    Ordinary filesystem path names are preserved byte-for-byte: only explicit
+    transport decoration (surrounding quotes and ``file:`` URIs) is unwrapped.
+    A path such as ``" report.hwpx "`` with meaningful surrounding whitespace is
+    therefore never silently redirected to a different, unspaced file.
+    """
 
-    parsed = urlsplit(text)
-    if parsed.scheme.lower() == "file":
+    text = os.fspath(value)
+
+    # Unwrap surrounding quotes only. Quotes are transport decoration, so the
+    # whitespace immediately inside them is decoration too and may be trimmed;
+    # the quoted payload itself is preserved.
+    stripped = text.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        text = stripped[1:-1].strip()
+
+    # Only treat the input as a URI when it actually carries the ``file`` scheme.
+    # Running URI parsing over ordinary paths is what previously mangled valid
+    # names, so unscheme'd input flows through untouched.
+    if text[:5].lower() == "file:":
+        try:
+            parsed = urlsplit(text)
+        except ValueError as exc:
+            # A malformed authority (e.g. ``file://[invalid]/x``) makes urlsplit
+            # raise; map it onto the typed workspace error contract instead of
+            # leaking an untyped parser exception, without echoing the input.
+            raise WorkspacePathError(
+                "workspace path is not a valid file URI",
+                code="WORKSPACE_PATH_INVALID",
+                reason="malformed_file_uri",
+            ) from exc
         path = unquote(parsed.path)
-        text = f"//{parsed.netloc}{path}" if parsed.netloc else path
+        authority = parsed.netloc
+        # An empty or ``localhost`` authority denotes the local host: resolve to
+        # the plain path. A non-local authority names a remote host, which is
+        # not an addressable local workspace path, so reject it explicitly
+        # rather than silently localizing or mangling it into a UNC reference.
+        if authority and authority.lower() != "localhost":
+            raise WorkspacePathError(
+                "workspace path names a non-local file URI authority",
+                code="WORKSPACE_PATH_INVALID",
+                reason="non_local_file_uri_authority",
+            )
+        text = path
 
     use_windows = os.name == "nt" if windows is None else windows
     if use_windows:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -57,6 +57,57 @@ def test_workspace_path_input_normalization(tmp_path: Path) -> None:
     )
 
 
+def test_ordinary_spaced_path_name_is_preserved(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    unspaced = root / "report.hwpx"
+    spaced = root / " report.hwpx "
+    unspaced.write_bytes(b"unspaced")
+    spaced.write_bytes(b"spaced")
+    resolver = WorkspaceResolver.from_roots([root])
+
+    # An ordinary path with meaningful surrounding whitespace must resolve to
+    # the byte-identical file, not be silently redirected to the unspaced one.
+    assert _normalize_path_input(" report.hwpx ") == " report.hwpx "
+    assert resolver.resolve(" report.hwpx ") == spaced
+    assert resolver.resolve("report.hwpx") == unspaced
+
+
+def test_file_uri_localhost_authority_resolves_local(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    document = root / "inside.hwpx"
+    document.write_bytes(b"document")
+    resolver = WorkspaceResolver.from_roots([root])
+
+    abs_path = str(document)
+    # Both an empty authority (file:///abs) and a localhost authority
+    # (file://localhost/abs) denote the same local file.
+    assert _normalize_path_input(f"file://{abs_path}") == abs_path
+    assert _normalize_path_input(f"file://localhost{abs_path}") == abs_path
+    assert _normalize_path_input(f"file://LOCALHOST{abs_path}") == abs_path
+    assert resolver.resolve(f"file://localhost{abs_path}") == document.resolve()
+    assert resolver.resolve(document.as_uri()) == document.resolve()
+
+
+def test_file_uri_non_local_authority_is_rejected() -> None:
+    # A remote host authority is not an addressable local workspace path; it
+    # must raise the typed contract rather than be localized or mangled.
+    with pytest.raises(WorkspacePathError) as excinfo:
+        _normalize_path_input("file://remotehost/inside.hwpx")
+    assert excinfo.value.code == "WORKSPACE_PATH_INVALID"
+    assert excinfo.value.reason == "non_local_file_uri_authority"
+
+
+def test_malformed_file_uri_raises_workspace_path_error() -> None:
+    with pytest.raises(WorkspacePathError) as excinfo:
+        _normalize_path_input("file://[invalid]/inside.hwpx")
+    assert excinfo.value.code == "WORKSPACE_PATH_INVALID"
+    assert excinfo.value.reason == "malformed_file_uri"
+    # The submitted path must not be exposed in the safe details.
+    assert "inside.hwpx" not in json.dumps(excinfo.value.safe_details())
+
+
 def test_missing_output_parent_is_created_inside_root(tmp_path: Path) -> None:
     root = tmp_path / "workspace"
     root.mkdir()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -14,6 +14,7 @@ from hwpx_mcp_server.workspace import (
     WorkspaceConfigurationError,
     WorkspacePathError,
     WorkspaceResolver,
+    _normalize_path_input,
 )
 
 
@@ -30,6 +31,30 @@ def test_relative_absolute_and_multi_root_resolution(tmp_path: Path) -> None:
     assert resolver.resolve(secondary / "inside.hwpx") == secondary / "inside.hwpx"
     assert resolver.display_path(primary / "inside.hwpx") == "inside.hwpx"
     assert resolver.display_path(secondary / "inside.hwpx") == str(secondary / "inside.hwpx")
+
+
+def test_workspace_path_input_normalization(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    document = root / "inside document.hwpx"
+    document.write_bytes(b"document")
+    resolver = WorkspaceResolver.from_roots([root])
+
+    assert resolver.resolve(f'"{document.as_uri()}"') == document.resolve()
+    assert (
+        _normalize_path_input(
+            r"file:///C:/Users/example/Documents/inside%20document.hwpx",
+            windows=True,
+        )
+        == r"C:\Users\example\Documents\inside document.hwpx"
+    )
+    assert (
+        _normalize_path_input(
+            r"'C:/Users/example\Documents/inside document.hwpx'",
+            windows=True,
+        )
+        == r"C:\Users\example\Documents\inside document.hwpx"
+    )
 
 
 def test_missing_output_parent_is_created_inside_root(tmp_path: Path) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -43,17 +43,17 @@ def test_workspace_path_input_normalization(tmp_path: Path) -> None:
     assert resolver.resolve(f'"{document.as_uri()}"') == document.resolve()
     assert (
         _normalize_path_input(
-            r"file:///C:/Users/example/Documents/inside%20document.hwpx",
+            r"file:///C:/workspace/Documents/inside%20document.hwpx",
             windows=True,
         )
-        == r"C:\Users\example\Documents\inside document.hwpx"
+        == r"C:\workspace\Documents\inside document.hwpx"
     )
     assert (
         _normalize_path_input(
-            r"'C:/Users/example\Documents/inside document.hwpx'",
+            r"'C:/workspace\Documents/inside document.hwpx'",
             windows=True,
         )
-        == r"C:\Users\example\Documents\inside document.hwpx"
+        == r"C:\workspace\Documents\inside document.hwpx"
     )
 
 
@@ -70,6 +70,8 @@ def test_ordinary_spaced_path_name_is_preserved(tmp_path: Path) -> None:
     # the byte-identical file, not be silently redirected to the unspaced one.
     assert _normalize_path_input(" report.hwpx ") == " report.hwpx "
     assert resolver.resolve(" report.hwpx ") == spaced
+    assert _normalize_path_input('" report.hwpx "') == " report.hwpx "
+    assert resolver.resolve('" report.hwpx "') == spaced
     assert resolver.resolve("report.hwpx") == unspaced
 
 


### PR DESCRIPTION
## 요약

따옴표로 감싼 경로, `file://` URI, 혼합된 Windows 경로 구분자를 기존 워크스페이스 경계 검사 전에 정규화합니다. 경계 검증 자체는 변경하지 않습니다.

## 관련 이슈

Fixes #74

## 변경 종류

- [ ] 버그 수정
- [x] 기능
- [ ] 문서
- [ ] 리팩터링

## 체크리스트

- [x] `python -m pytest -q` 테스트가 통과합니다.
- [ ] `CHANGELOG.md`를 갱신했습니다(해당하는 경우).
- [x] 문서 갱신이 필요한지 확인했습니다.
