### PR TITLE
ci: guard security reporting and native smoke receipts

### DIFF
--- a/.github/workflows/security-policy-drift.yml
+++ b/.github/workflows/security-policy-drift.yml
@@ -1,0 +1,54 @@
+name: Security Policy Drift
+
+on:
+  pull_request:
+    paths:
+      - SECURITY.md
+      - .github/workflows/security-policy-drift.yml
+  push:
+    branches:
+      - main
+    paths:
+      - SECURITY.md
+      - .github/workflows/security-policy-drift.yml
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  private-vulnerability-reporting:
+    name: Private vulnerability reporting is enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository security setting
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{repository}/private-vulnerability-reporting",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "User-Agent": "security-policy-drift-check",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              payload = json.load(response)
+
+          if payload.get("enabled") is not True:
+              raise SystemExit(
+                  "Private vulnerability reporting is disabled while SECURITY.md "
+                  "advertises the private reporting form."
+              )
+          print(f"Private vulnerability reporting is enabled for {repository}.")
+          PY

--- a/scripts/check_platform_optional_smoke.py
+++ b/scripts/check_platform_optional_smoke.py
@@ -30,7 +30,7 @@ ROOT = Path(__file__).resolve().parents[1]
 MINIMUM_PYTHON = (3, 10)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from release_coordinates import coordinates as _release_coordinates  # noqa: E402
+from release_coordinates import coordinates as _release_coordinates
 
 # Train coordinates are derived from identity.json, never restated here. A
 # stale wheel-filename pin in this very file produced the preserved failure
@@ -48,6 +48,7 @@ _SOURCE_AFFECTING_ENV = (
     "PYTHONUSERBASE",
     "VIRTUAL_ENV",
 )
+_PROBE_RECEIPT_PREFIX = "HWPX_PLATFORM_SMOKE_RECEIPT="
 
 
 def _isolated_env(
@@ -171,6 +172,40 @@ def _resolve_probe(script: str) -> str:
     return resolved
 
 
+def _parse_probe_receipt(
+    completed: subprocess.CompletedProcess[str],
+) -> dict[str, Any]:
+    """Extract the probe receipt without trusting third-party stdout silence."""
+
+    receipts = [
+        line.removeprefix(_PROBE_RECEIPT_PREFIX)
+        for line in completed.stdout.splitlines()
+        if line.startswith(_PROBE_RECEIPT_PREFIX)
+    ]
+    if len(receipts) != 1:
+        raise RuntimeError(
+            "probe must emit exactly one prefixed receipt; "
+            f"got {len(receipts)}\n"
+            f"stdout={completed.stdout!r}\n"
+            f"stderr={completed.stderr!r}"
+        )
+    try:
+        receipt = json.loads(receipts[0])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "probe emitted a malformed receipt\n"
+            f"stdout={completed.stdout!r}\n"
+            f"stderr={completed.stderr!r}"
+        ) from exc
+    if not isinstance(receipt, dict):
+        raise TypeError(
+            "probe receipt must be a JSON object\n"
+            f"stdout={completed.stdout!r}\n"
+            f"stderr={completed.stderr!r}"
+        )
+    return receipt
+
+
 def _probe_script() -> str:
     return r"""
 import importlib.util
@@ -244,7 +279,7 @@ assert report.warnings
 assert "RENDER_ORACLE_UNAVAILABLE" in report.warnings[0]
 assert "unverified" in report.warnings[0]
 
-print(json.dumps(
+print("HWPX_PLATFORM_SMOKE_RECEIPT=" + json.dumps(
     {
         "python": platform.python_version(),
         "platform": sys.platform,
@@ -258,7 +293,7 @@ print(json.dumps(
         "renderWarning": report.warnings[0],
     },
     sort_keys=True,
-))
+), flush=True)
 """
 
 
@@ -374,7 +409,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=probe_cwd,
             env=probe_env,
         )
-        probe_receipt: dict[str, Any] = json.loads(probe.stdout)
+        probe_receipt = _parse_probe_receipt(probe)
 
         task_cli = _run(
             [str(venv_python), "-m", "hwpx_automation", "--help"],

--- a/tests/test_platform_optional_smoke_gate.py
+++ b/tests/test_platform_optional_smoke_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -41,6 +42,57 @@ def test_native_probe_executes_owned_imaging_stack_without_gui() -> None:
     assert "np.asarray" in probe
     assert "fitz-pillow-numpy-passed" in probe
     assert "MacHancomOracle" not in probe
+    assert smoke._PROBE_RECEIPT_PREFIX in probe
+
+
+def test_probe_receipt_parser_ignores_unowned_stdout() -> None:
+    receipt = {"oracleBackend": "NullOracle", "renderChecked": False}
+    completed = subprocess.CompletedProcess(
+        args=["python", "-c", "probe"],
+        returncode=0,
+        stdout=(
+            "optional dependency diagnostic\n"
+            f"{smoke._PROBE_RECEIPT_PREFIX}{json.dumps(receipt)}\n"
+        ),
+        stderr="native library diagnostic\n",
+    )
+
+    assert smoke._parse_probe_receipt(completed) == receipt
+
+
+@pytest.mark.parametrize(
+    "stdout, message",
+    [
+        ("", "got 0"),
+        (
+            f"{smoke._PROBE_RECEIPT_PREFIX}not-json\n",
+            "malformed receipt",
+        ),
+        (
+            "".join(
+                [
+                    f"{smoke._PROBE_RECEIPT_PREFIX}{{}}\n",
+                    f"{smoke._PROBE_RECEIPT_PREFIX}{{}}\n",
+                ]
+            ),
+            "got 2",
+        ),
+    ],
+)
+def test_probe_receipt_parser_fails_closed(
+    stdout: str,
+    message: str,
+) -> None:
+    completed = subprocess.CompletedProcess(
+        args=["python", "-c", "probe"],
+        returncode=0,
+        stdout=stdout,
+        stderr="captured probe stderr",
+    )
+
+    with pytest.raises(RuntimeError, match=message) as caught:
+        smoke._parse_probe_receipt(completed)
+    assert "captured probe stderr" in str(caught.value)
 
 
 def test_platform_optional_smoke_sanitizes_source_resolution(


### PR DESCRIPTION
## What changed

- add a scheduled and change-triggered check for the repository's Private Vulnerability Reporting setting
- fail when `SECURITY.md` advertises the private report form but the GitHub setting is disabled
- make the minimum-Python native smoke probe emit and parse a uniquely prefixed receipt, so optional dependencies may write diagnostics without corrupting the gate protocol
- fail closed with captured stdout/stderr when the receipt is missing, duplicated, malformed, or not an object

## Root cause

The same configuration drift reported in airmang/python-hwpx#83 affected this repository: `SECURITY.md` advertised the private form while the repository setting was disabled.

The first PR run also exposed a pre-existing cross-platform gate defect: the child probe returned success, but the parent attempted to decode the whole stdout stream as JSON. Native/optional dependencies do not guarantee stdout silence, so both macOS and Windows failed at `json.loads(probe.stdout)`.

## Validation

- authenticated GitHub API: `enabled=true`
- unauthenticated GitHub API: `enabled=true`
- workflow YAML parsed locally
- the workflow's exact API check passed locally
- platform smoke parser tests: 9 passed
- Ruff and mypy passed for the touched seam
- native imaging + structural-only `NullOracle` probe passed locally
- GitHub Actions: Tests, CodeQL, Dependency review, and Security Policy Drift passed
- Python 3.10 macOS and Windows clean oracle boundaries passed

Related: airmang/python-hwpx#83