### PR TITLE
fix: open workspace snapshots with O_BINARY so Windows saves publish

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,6 +132,31 @@ jobs:
           python scripts/render_contract_delta.py --check
         working-directory: python-hwpx-automation
 
+  # Issue #98: every Windows save failed because os.open defaulted to CRT
+  # text mode, so snapshot digests never matched binary reads. POSIX runners
+  # cannot reproduce text-mode descriptor semantics, so the workspace
+  # publication fallback must be exercised on a real Windows runner.
+  windows-publish-gate:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: python-hwpx-automation
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: airmang/python-hwpx
+          ref: ${{ vars.PYTHON_HWPX_CANDIDATE_REF || 'main' }}
+          path: python-hwpx
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      - run: python -m pip install -e "../python-hwpx[visual,preview]"
+        working-directory: python-hwpx-automation
+      - run: python -m pip install -e ".[mcp,test]"
+        working-directory: python-hwpx-automation
+      - run: python -m pytest -q tests/test_workspace_windows_gate.py
+        working-directory: python-hwpx-automation
+
   clean-package-install:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### 고쳐짐
+
+- **Windows에서 모든 저장·삭제 경로가 `WORKSPACE_PATH_CHANGED`
+  (`output_target_changed` / `output_candidate_changed`)로 실패하던 결함을
+  수정했습니다 (#98).** Windows `os.open`은 CRT 텍스트 모드가 기본이라
+  workspace 스냅샷 digest가 CRLF 변환과 0x1A 조기 EOF를 거친 바이트를
+  해시했고, 바이너리로 읽은 실제 파일 바이트와 절대 일치할 수 없었습니다.
+  ZIP 컨테이너인 HWPX에는 두 바이트 패턴이 항상 존재하므로 Windows의
+  portable 폴백 공표는 전부 차단됐습니다. `_snapshot_target`과
+  `_relative_file_snapshot`이 `O_BINARY`로 열도록 고치고, 실제 Windows
+  러너에서 공표 폴백을 실행하는 CI 게이트
+  (`tests/test_workspace_windows_gate.py`, `windows-publish-gate` 잡)를
+  추가했습니다.
+
 ## [7.0.1] - 2026-08-04
 
 `v7.0.0`은 보존된 실패 태그입니다 — 아무것도 게시되지 않았습니다.

--- a/src/hwpx_automation/workspace.py
+++ b/src/hwpx_automation/workspace.py
@@ -107,6 +107,9 @@ def _snapshot_target(
         os.O_RDONLY
         | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_NONBLOCK", 0)
+        # Windows os.open defaults to CRT text mode, which rewrites CRLF and
+        # stops reading at 0x1A; digests must hash the exact on-disk bytes.
+        | getattr(os, "O_BINARY", 0)
     )
     try:
         descriptor = os.open(path, flags)
@@ -226,6 +229,7 @@ def _relative_file_snapshot(
         os.O_RDONLY
         | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_BINARY", 0)
     )
     descriptor = os.open(name, flags, dir_fd=parent_fd)
     try:

--- a/tests/test_workspace_windows_gate.py
+++ b/tests/test_workspace_windows_gate.py
@@ -1,0 +1,159 @@
+"""Regression gate for Windows portable-fallback publication (issue #98).
+
+On Windows ``os.open`` defaults to CRT text mode: reads translate CRLF and
+stop at the first 0x1A byte. Every HWPX payload is a ZIP container, so both
+byte patterns always occur, and a snapshot digest taken through a text-mode
+descriptor can never match the same file read in binary mode. POSIX runners
+cannot reproduce text-mode descriptor semantics, so this file doubles as the
+scoped suite the Windows CI job executes on a real Windows runner.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+import hwpx_automation.workspace as workspace_module
+from hwpx_automation.workspace import WorkspaceResolver
+
+# CRLF plus 0x1A: the byte sequences the Windows CRT text mode rewrites or
+# truncates at. Real HWPX (ZIP) payloads always contain both.
+TEXT_MODE_HOSTILE = b"PK\x03\x04\r\nbody\x1atrailer\r\n\x00\x1a" * 3
+
+
+def _force_portable_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(workspace_module, "_descriptor_cas_supported", lambda: False)
+
+
+def test_snapshot_target_opens_descriptor_in_binary_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "sample.hwpx"
+    target.write_bytes(TEXT_MODE_HOSTILE)
+    on_windows = os.name == "nt"
+    binary_flag = getattr(os, "O_BINARY", 0) if on_windows else 0x40000000
+    if not on_windows:
+        monkeypatch.setattr(os, "O_BINARY", binary_flag, raising=False)
+    real_open = os.open
+    seen_flags: list[int] = []
+
+    def recording_open(path, flags, *args, **kwargs):
+        seen_flags.append(flags)
+        if not on_windows:
+            flags &= ~binary_flag
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(workspace_module.os, "open", recording_open)
+
+    existed, _, _, digest, _ = workspace_module._snapshot_target(target)
+
+    assert existed
+    assert digest == hashlib.sha256(TEXT_MODE_HOSTILE).hexdigest()
+    assert seen_flags and all(flags & binary_flag for flags in seen_flags)
+
+
+@pytest.mark.skipif(
+    os.open not in os.supports_dir_fd,
+    reason="descriptor-relative snapshots require dir_fd support",
+)
+def test_relative_file_snapshot_opens_descriptor_in_binary_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "sample.hwpx"
+    target.write_bytes(TEXT_MODE_HOSTILE)
+    binary_flag = 0x40000000
+    monkeypatch.setattr(os, "O_BINARY", binary_flag, raising=False)
+    real_open = os.open
+    seen_flags: list[int] = []
+
+    def recording_open(path, flags, *args, **kwargs):
+        seen_flags.append(flags)
+        flags &= ~binary_flag
+        return real_open(path, flags, *args, **kwargs)
+
+    parent_fd = os.open(tmp_path, os.O_RDONLY)
+    try:
+        monkeypatch.setattr(workspace_module.os, "open", recording_open)
+        _, _, digest, _ = workspace_module._relative_file_snapshot(
+            parent_fd,
+            target.name,
+        )
+    finally:
+        monkeypatch.setattr(workspace_module.os, "open", real_open)
+        os.close(parent_fd)
+
+    assert digest == hashlib.sha256(TEXT_MODE_HOSTILE).hexdigest()
+    assert seen_flags and all(flags & binary_flag for flags in seen_flags)
+
+
+def test_read_guarded_bytes_fallback_matches_binary_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_portable_fallback(monkeypatch)
+    root = tmp_path / "workspace"
+    root.mkdir()
+    target = root / "target.hwpx"
+    target.write_bytes(TEXT_MODE_HOSTILE)
+    resolver = WorkspaceResolver.from_roots([root])
+    guard = resolver.capture_output(target)
+
+    assert resolver.read_guarded_bytes(guard) == TEXT_MODE_HOSTILE
+
+
+def test_portable_fallback_inplace_publish_survives_text_mode_hostile_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_portable_fallback(monkeypatch)
+    root = tmp_path / "workspace"
+    root.mkdir()
+    target = root / "target.hwpx"
+    target.write_bytes(TEXT_MODE_HOSTILE)
+    resolver = WorkspaceResolver.from_roots([root])
+    guard = resolver.capture_output(target)
+    updated = TEXT_MODE_HOSTILE + b"\r\n\x1aupdated"
+
+    published = resolver.atomic_write_bytes(guard, updated)
+
+    assert published == guard.path
+    assert target.read_bytes() == updated
+
+
+def test_portable_fallback_new_output_publish_survives_text_mode_hostile_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_portable_fallback(monkeypatch)
+    root = tmp_path / "workspace"
+    root.mkdir()
+    target = root / "fresh.hwpx"
+    resolver = WorkspaceResolver.from_roots([root])
+    guard = resolver.capture_output(target)
+
+    published = resolver.atomic_write_bytes(guard, TEXT_MODE_HOSTILE)
+
+    assert published == guard.path
+    assert target.read_bytes() == TEXT_MODE_HOSTILE
+
+
+def test_portable_fallback_remove_output_survives_text_mode_hostile_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_portable_fallback(monkeypatch)
+    root = tmp_path / "workspace"
+    root.mkdir()
+    target = root / "target.hwpx"
+    target.write_bytes(TEXT_MODE_HOSTILE)
+    resolver = WorkspaceResolver.from_roots([root])
+    guard = resolver.capture_output(target)
+
+    resolver.remove_output(guard)
+
+    assert not target.exists()


### PR DESCRIPTION
## 요약

Windows에서 모든 쓰기/저장/삭제 경로가 `WORKSPACE_PATH_CHANGED`로 실패하던 결함(#98)을 수정합니다.

**근본 원인**: Windows `os.open`은 CRT 텍스트 모드가 기본입니다. 텍스트 모드 디스크립터의 `os.read`는 CRLF를 LF로 변환하고 첫 0x1A(Ctrl-Z)에서 EOF 처리합니다. `_snapshot_target`이 이 모드로 digest를 계산했기 때문에:

- guard 기준선과 재스냅샷은 서로 일치(둘 다 같은 방식으로 잘못됨) → 리포터의 "3회 호출 STABLE" 관찰과 정합
- 그러나 `read_guarded_bytes`의 `sha256(guard.path.read_bytes())`(진짜 바이너리)와는 절대 불일치 → `authorized file changed while it was read` (in-place 저장)
- 신규 `output=` 경로는 후보 검증 `candidate_digest != sha256(data)`에서 → `output candidate changed before publication`

HWPX는 ZIP 컨테이너라 CRLF/0x1A가 항상 존재하므로 Windows portable 폴백 공표가 전부 결정적으로 차단됐습니다.

## 변경

- `_snapshot_target` / `_relative_file_snapshot`의 `os.open`에 `getattr(os, "O_BINARY", 0)` 추가 (POSIX에서는 no-op)
- 전 플랫폼 회귀 스위트 `tests/test_workspace_windows_gate.py` 추가: 텍스트모드 적대 바이트(CRLF+0x1A)로 in-place 공표·신규 출력 공표·guarded 읽기·guarded 삭제 왕복 + 스냅샷 open 플래그에 O_BINARY 포함 검증
- CI에 `windows-publish-gate` 잡 추가 — POSIX 러너로는 텍스트모드 semantics를 재현할 수 없으므로 실제 windows-latest 러너에서 위 스위트를 실행 (#98 리포터 제안 수용)

## 검증

- `pytest tests/test_workspace_windows_gate.py tests/test_workspace.py` 53 passed
- 워크플로 구조 게이트 4파일 15 passed, `ruff check --select E9,F` 통과, `check_public_hygiene.py` OK
- 전체 스위트 로컬 실행 중 (머지 전 CI로 재확인)

## 관련 이슈

Fixes #98

## 변경 종류

- [x] 버그 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)