### PR TITLE
fix: drop dead private border-fills item-count call removed in core 6.1.0

### DIFF
--- a/scripts/check_architecture_ratchets.py
+++ b/scripts/check_architecture_ratchets.py
@@ -64,7 +64,10 @@ EXPECTED_SERVICE_LINES = {
     # printed a byteIdentical receipt onto a rewritten document. The seam now
     # refuses the impossible combination rather than forwarding it.
     "save_policy.py": 616,
-    "tables.py": 539,
+    # core 6.1.0 removed HwpxOxmlHeader._update_border_fills_item_count; the
+    # hasattr fallback (equivalent direct itemCnt computation) is now the only
+    # branch, so the dead private call went away.
+    "tables.py": 536,
     "transactions.py": 616,
 }
 

--- a/src/hwpx_automation/ops_services/tables.py
+++ b/src/hwpx_automation/ops_services/tables.py
@@ -211,11 +211,8 @@ class TableService:
         new_id = header._allocate_border_fill_id(border_fills_element)
         _build_border_fill_element(border_fills_element, new_id, spec)
 
-        if hasattr(header, "_update_border_fills_item_count"):
-            header._update_border_fills_item_count(border_fills_element)
-        else:
-            count = len(border_fills_element.findall(f"{HH_NS}borderFill"))
-            border_fills_element.set("itemCnt", str(count))
+        count = len(border_fills_element.findall(f"{HH_NS}borderFill"))
+        border_fills_element.set("itemCnt", str(count))
         header.mark_dirty()
         return new_id
 


### PR DESCRIPTION
## 요약

core 6.1.0이 `HwpxOxmlHeader._update_border_fills_item_count`를 범용 `_update_item_count` 헬퍼로 대체하면서, `ops_services/tables.py`의 `hasattr` 분기가 죽은 코드가 됐고 pyright가 6.1.0 표면 기준으로 해당 속성 접근을 거부해 **main의 모든 test 매트릭스 잡이 빨간 상태**였습니다.

기존 폴백 분기가 이미 동일한 itemCnt 계산을 직접 수행하므로, 죽은 private 호출을 제거하고 직접 계산만 남깁니다. 런타임 동작 변화는 없습니다(6.0.x에서도 폴백과 helper는 동일 의미).

## 배경

core 6.1.0 발행(#89 트랜지션 트랙 참고) 후 저장소 변수 `PYTHON_HWPX_CANDIDATE_REF`가 core 6.0.2 릴리스 커밋에 고정된 채 남아 있었습니다. 이 stale 핀은 (1) platform smoke가 6.1.0 휠을 기대해 실패하게 만들었고, (2) test 매트릭스는 6.0.2 기준으로 type-check해 이 드리프트를 가려 왔습니다. 변수를 제거해 문서화된 규칙(코어 릴리스가 main에 안착하면 main이 정본)을 복원하자 이 결함이 드러났습니다.

- `tables.py` 라인수 래칫 539→536 갱신(사유 주석 포함)
- 로컬 검증: 관련 스위트 135 passed, 래칫 캡처 일치, public hygiene OK. pyright는 core main 기준이라 CI가 최종 검증입니다.

## 변경 종류

- [x] 버그 수정 (CI/타입 게이트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)